### PR TITLE
The search now also searches in the task field

### DIFF
--- a/app/src/utils/services/DataService.ts
+++ b/app/src/utils/services/DataService.ts
@@ -47,7 +47,11 @@ class DataService {
                                 radius: string
                             }): Promise<any> {
         const query = new QueryBuilder();
-        query.mustShouldMatch(searchValues.map((value) => [{key: 'title', value}, {key: 'categories', value}]).flat());
+        query.mustShouldMatch(searchValues.map((value) => [
+                {key: 'title', value},
+                {key: 'categories', value},
+                {key: 'task', value}
+            ]).flat());
 
         query.size(100);
         const queryObject = query.build();


### PR DESCRIPTION
The text search now searches in the following fields:
'title', 'categories', 'task'

Is this sufficient, or shall the fields 'organization', 'location' and 'contact' also be searched?