### PR TITLE
Issue58

### DIFF
--- a/app/src/views/ResultPage.vue
+++ b/app/src/views/ResultPage.vue
@@ -65,14 +65,14 @@
 
           <!--display content on the right side-->
           <v-card-text style="padding:0 10px;">
-            <v-simple-table class="no-border">
+            <v-simple-table class="no-border detail-table">
               <tbody>
               <tr v-if="selectedPost.location">
                 <td>Einsatzort</td>
                 <td v-html="selectedPost.location"></td>
               </tr>
               <tr class="pt-1" v-if="selectedPost.title">
-                <td >Aufgabe</td>
+                <td>Aufgabe</td>
                 <td v-html="selectedPost.task"></td>
               </tr>
               <tr class="pt-1" v-if="selectedPost.contact">
@@ -293,7 +293,15 @@
    .no-border tr:not(:last-child) td:not(.v-data-table__mobile-row) {
     border: 0 !important;
    }
-  .no-border tr:hover {
+   .detail-table tr:hover {
     background: unset !important;
-  }
+   }
+   .detail-table tr {
+     margin-bottom: 10px;
+   }
+   .detail-table tr td {
+     vertical-align: top;
+     padding-bottom: 25px;
+   }
+
 </style>

--- a/app/src/views/ResultPage.vue
+++ b/app/src/views/ResultPage.vue
@@ -64,7 +64,7 @@
           </v-list-item>
 
           <!--display content on the right side-->
-          <v-card-text style="padding-left:5%; padding-right:5%">
+          <v-card-text style="padding:0 10px;">
             <v-simple-table class="no-border">
               <tbody>
               <tr v-if="selectedPost.location">

--- a/app/src/views/ResultPage.vue
+++ b/app/src/views/ResultPage.vue
@@ -65,42 +65,46 @@
 
           <!--display content on the right side-->
           <v-card-text style="padding-left:5%; padding-right:5%">
-            <v-row v-if="selectedPost.location">
-             <v-flex lg2 md4 xs6>Einsatzort</v-flex>
-             <v-flex lg10 md8 xs6 v-html="selectedPost.location"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.title">
-             <v-flex lg2 md4 xs6 >Aufgabe</v-flex>
-             <v-flex lg10 md8 xs6 v-html="selectedPost.task"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.contact">
-              <v-flex lg2 md4 xs6>Ansprechpartner</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.contact"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.organization">
-              <v-flex lg2 md4 xs6>Organisation</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.organization"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.target_group">
-              <v-flex lg2 md4 xs6>Zielgruppe</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.target_group"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.timing">
-              <v-flex lg2 md4 xs6>Einstiegsdatum / Beginn</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.timing"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.effort">
-              <v-flex lg2 md4 xs6>Zeitaufwand</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.effort"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.opportunities">
-              <v-flex lg2 md4 xs6>Möglichkeiten</v-flex>
-              <v-flex lg10 md8 xs6 v-html="selectedPost.opportunities"></v-flex>
-            </v-row>
-            <v-row class="pt-1" v-if="selectedPost.link">
-              <v-flex lg2 md4 xs6>Quelle</v-flex>
-              <v-flex lg10 md8 xs6><a :href="selectedPost.link" target="_blank">{{ selectedPost.source }}</a></v-flex>
-            </v-row>
+            <v-simple-table class="no-border">
+              <tbody>
+              <tr v-if="selectedPost.location">
+                <td>Einsatzort</td>
+                <td v-html="selectedPost.location"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.title">
+                <td >Aufgabe</td>
+                <td v-html="selectedPost.task"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.contact">
+                <td>Ansprechpartner</td>
+                <td v-html="selectedPost.contact"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.organization">
+                <td>Organisation</td>
+                <td v-html="selectedPost.organization"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.target_group">
+                <td>Zielgruppe</td>
+                <td v-html="selectedPost.target_group"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.timing">
+                <td>Einstiegsdatum / Beginn</td>
+                <td v-html="selectedPost.timing"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.effort">
+                <td>Zeitaufwand</td>
+                <td v-html="selectedPost.effort"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.opportunities">
+                <td>Möglichkeiten</td>
+                <td v-html="selectedPost.opportunities"></td>
+              </tr>
+              <tr class="pt-1" v-if="selectedPost.link">
+                <td>Quelle</td>
+                <td><a :href="selectedPost.link" target="_blank">{{ selectedPost.source }}</a></td>
+              </tr>
+              </tbody>
+            </v-simple-table>
           </v-card-text>
 
           <v-card-actions>
@@ -286,4 +290,10 @@
    .activeListItem {
      background-color: #c4e0ff;
    }
+   .no-border tr:not(:last-child) td:not(.v-data-table__mobile-row) {
+    border: 0 !important;
+   }
+  .no-border tr:hover {
+    background: unset !important;
+  }
 </style>

--- a/app/src/views/ResultPage.vue
+++ b/app/src/views/ResultPage.vue
@@ -47,9 +47,8 @@
             </v-btn> -->
 
             <!--display title, subtitle and image on the right side-->
-            <v-list-item-content style="margin-top:2%" class="headline">{{
-                selectedPost.title
-              }}
+            <v-list-item-content style="margin-top:2%" class="headline">
+              {{selectedPost.title}}
             </v-list-item-content>
             <v-img
               style="margin-top:2%"
@@ -67,40 +66,40 @@
           <!--display content on the right side-->
           <v-card-text style="padding-left:5%; padding-right:5%">
             <v-row v-if="selectedPost.location">
-             <v-flex md4 xs6>Einsatzort</v-flex>
-             <v-flex md8 xs6 v-html="selectedPost.location"></v-flex>
+             <v-flex lg2 md4 xs6>Einsatzort</v-flex>
+             <v-flex lg10 md8 xs6 v-html="selectedPost.location"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.title">
-             <v-flex md4 xs6 >Aufgabe</v-flex>
-             <v-flex md8 xs6 v-html="selectedPost.task"></v-flex>
+             <v-flex lg2 md4 xs6 >Aufgabe</v-flex>
+             <v-flex lg10 md8 xs6 v-html="selectedPost.task"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.contact">
-              <v-flex md4 xs6>Ansprechpartner</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.contact"></v-flex>
+              <v-flex lg2 md4 xs6>Ansprechpartner</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.contact"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.organization">
-              <v-flex md4 xs6>Organisation</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.organization"></v-flex>
+              <v-flex lg2 md4 xs6>Organisation</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.organization"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.target_group">
-              <v-flex md4 xs6>Zielgruppe</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.target_group"></v-flex>
+              <v-flex lg2 md4 xs6>Zielgruppe</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.target_group"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.timing">
-              <v-flex md4 xs6>Einstiegsdatum / Beginn</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.timing"></v-flex>
+              <v-flex lg2 md4 xs6>Einstiegsdatum / Beginn</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.timing"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.effort">
-              <v-flex md4 xs6>Zeitaufwand</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.effort"></v-flex>
+              <v-flex lg2 md4 xs6>Zeitaufwand</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.effort"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.opportunities">
-              <v-flex md4 xs6>Möglichkeiten</v-flex>
-              <v-flex md8 xs6 v-html="selectedPost.opportunities"></v-flex>
+              <v-flex lg2 md4 xs6>Möglichkeiten</v-flex>
+              <v-flex lg10 md8 xs6 v-html="selectedPost.opportunities"></v-flex>
             </v-row>
             <v-row class="pt-1" v-if="selectedPost.link">
-              <v-flex md4 xs6>Quelle</v-flex>
-              <v-flex md8 xs6><a :href="selectedPost.link" target="_blank">{{ selectedPost.source }}</a></v-flex>
+              <v-flex lg2 md4 xs6>Quelle</v-flex>
+              <v-flex lg10 md8 xs6><a :href="selectedPost.link" target="_blank">{{ selectedPost.source }}</a></v-flex>
             </v-row>
           </v-card-text>
 
@@ -139,12 +138,12 @@
               <v-card class="mb-3" :class="{ activeListItem: currentPostId === post.id }">
                 <v-list-item three-line @click="openPost(post.id)">
                   <v-list-item-content>
-                    <v-list-item-title class="headline mb-1">{{
-                      post.title
-                    }}</v-list-item-title>
-                    <v-list-item-subtitle>{{
-                      post.task
-                    }}</v-list-item-subtitle>
+                    <v-list-item-title class="headline mb-1">
+                      {{post.title}}
+                    </v-list-item-title>
+                    <v-list-item-subtitle>
+                      {{post.location}} &mdash; {{post.task}}
+                    </v-list-item-subtitle>
                   </v-list-item-content>
 
                   <v-img


### PR DESCRIPTION
+ Display post location in subtitle

![grafik](https://user-images.githubusercontent.com/12964877/85776681-3b9a6780-b721-11ea-9656-4f5d00d1985d.png)


---

* reduced whitespace between labels and values on ResultPage by using table

a proposal for the fix of issue #58 

On Desktop:
![grafik](https://user-images.githubusercontent.com/12964877/85776493-10177d00-b721-11ea-9106-e621b6e37793.png)

On Mobile:
![grafik](https://user-images.githubusercontent.com/12964877/85776594-245b7a00-b721-11ea-844a-d49c70ef5fc3.png)


