### PR TITLE
Implemented check, if a post is volunteering work

### DIFF
--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -73,7 +73,8 @@ class Scraper:
         try:
             detail_page = self.soupify(url)
             parsed_data = self.parse(detail_page, url)
-            append_data_to_json(os.path.join(ROOT_DIR, 'data_extraction/data', f'{self.name}.json'), parsed_data)
+            if parsed_data is not None:
+                append_data_to_json(os.path.join(ROOT_DIR, 'data_extraction/data', f'{self.name}.json'), parsed_data)
 
         except Exception as err:
             self.add_error({'fn': 'parse', 'body': str(err), 'index': index, 'url': url})

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -13,6 +13,12 @@ class EhrenamtHessenScraper(Scraper):
     def parse(self, response, url):
         """Handles the soupified response of a detail page in the predefined way and returns it."""
 
+        tab = response.find('a', {'href': '?param&searchTab=jobentries&entryTypeId=5&showEntryTypeFilterSelect=false'})
+        tab_parent_div = tab.parent
+        tab_classes = tab_parent_div['class']
+        if 'active' not in tab_classes:
+            return None
+
         location_of = response.find('div', {'class': 'legendLeft'}, text='Ort Ihres Ehrenamts')
         location = None
         lat = 0

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -17,6 +17,8 @@ class EhrenamtHessenScraper(Scraper):
         tab_parent_div = tab.parent
         tab_classes = tab_parent_div['class']
         if 'active' not in tab_classes:
+            if self.debug:
+                print(f'[INFO]\t\'{url}\' is not volunteering work')
             return None
 
         location_of = response.find('div', {'class': 'legendLeft'}, text='Ort Ihres Ehrenamts')


### PR DESCRIPTION
Closes #201.

This can be tested with the following commands:
```
$ cd <git-repo>/etl
$ python (or python3)
>>> import os
>>> import sys
>>> ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
>>> os.environ['ROOT_DIR'] = ROOT_DIR
>>> sys.path.extend([f'{ROOT_DIR}/data_extraction', f'{ROOT_DIR}/shared'])
>>> from data_extraction.scraper.ehrenamt_hessen import EhrenamtHessenScraper as e
>>> a = e('ehrenamt_hessen')
>>> a.crawl('https://www.ehrenamtssuche-hessen.de/index.cfm?searchTab=job_entry_detail&jobEntryId=121912&searchLocationId=0&searchDistance=0&searchSectorIds=&searchSearchterm=&backLink=%3Fparam%26searchTab%3Dentries%26countyId%3D24%26locationId%3D424', 1)
(this added a new post to the file <git-repo>/etl/data_enhancement/data/ehrenamt_hessen.json)
>>> a.crawl('https://www.ehrenamtssuche-hessen.de/index.cfm?searchTab=event_detail&&eventId=4537&searchLocationId=0&searchDistance=0&searchSectorIds=&searchSearchterm=health&backLink=%3Fparam%26searchTab%3Dentries%26countyId%3D23%26locationId%3D423', 2)
(this added NO post to the file <git-repo>/etl/data_enhancement/data/ehrenamt_hessen.json)
```

You can also choose different links from ehrenamtssuche-hessen.de.