### PR TITLE
216 Added crawler for ein-jahr-freiwillig.de

### DIFF
--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -19,6 +19,7 @@
             <li><a href="https://www.ehrenamtssuche-hessen.de/" target="_blank" rel="noopener">www.ehrenamtssuche-hessen.de</a></li>
             <li><a href="https://www.gute-tat.de/" target="_blank" rel="noopener">www.gute-tat.de</a></li>
             <li><a href="https://www.weltwaerts.de" target="_blank" rel="noopener">www.weltwaerts.de</a></li>
+            <li><a href="https://ein-jahr-freiwillig.de" target="_blank" rel="noopener">www.ein-jahr-freiwillig.de</a></li>
           </ul>
           <p>
             <br />

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -57,4 +57,4 @@ class Enhancer:
 
     def __enhance_ein_jahr_freiwillig(self):
         """ domain specific enhancement for ein-jahr-freiwillig """
-        pass
+        e_tags.run(self.__data, self.__domain_name)

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -21,6 +21,8 @@ class Enhancer:
             'gutetat_berlin': self.__enhance_gute_tat,
             'gutetat_hamburg': self.__enhance_gute_tat,
             'gutetat_munich': self.__enhance_gute_tat,
+            'ein_jahr_freiwillig': self.__enhance_ein_jahr_freiwillig,
+
         }
 
     def run(self):
@@ -49,4 +51,8 @@ class Enhancer:
 
     def __enhance_gute_tat(self):
         """ domain specific enhancement for gute-tat website group"""
+        pass
+
+    def __enhance_ein_jahr_freiwillig(self):
+        """ domain specific enhancement for ein-jahr-freiwillig """
         pass

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -4,7 +4,7 @@ import time
 import requests
 from bs4 import BeautifulSoup
 
-from utils import append_data_to_json, write_data_to_json
+from shared.utils import append_data_to_json, write_data_to_json
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/etl/data_extraction/scraper/ein-jahr-freiwillig.py
+++ b/etl/data_extraction/scraper/ein-jahr-freiwillig.py
@@ -1,0 +1,118 @@
+from data_extraction.Scraper import Scraper
+
+
+class Ein_Jahr_Freiwillig(Scraper):
+    """Scrapes the website ein-jahr-freiwillig.de."""
+
+    base_url = 'https://ein-jahr-freiwillig.de'
+    debug = True
+
+    def parse(self, response, url):
+        """Handles the soupified response of a detail page in the predefined way and returns it"""
+
+        parsed_object = {
+            'title': response.find('span', {'class': 'field field--name-title field--type-string field--label-hidden'}).decode_contents().strip() or None,
+            'location': response.find('p', {'class': 'address'}).decode_contents().strip() or None,
+            'task': response.find('div', {'class' :'clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item'}).p[2].decode_contents().strip() or None,
+            'target_group': None,
+            'timing': response.find('div', {'class': 'field field--name-field-field-verfuegbar-ab field--type-string field--label-above'}).find('div', {'class': 'field__item'}).decode_contents().strip() or None,
+            'effort': response.find('div', {'class': 'field field--name-field-laenge-dienstzeit field--type-string field--label-above'}).find('div', {'class': 'field__item'}).decode_contents().strip() or None,
+            'opportunities': None,
+            'organization': response.find('div', {'class': 'field field--name-field-traeger field--type-entity-reference field--label-above'}).find('div')[2].decode_contents().strip() or None,
+            'contact': None,
+            'link': url or None,
+            'source': self.base_url,
+            'geo_location':  None,
+            'requirements': response.find('div', {'class': 'field field--name-field-voraussetzungen field--type-string-long field--label-above'}).find('div', {'class': 'field__item'}).decode_contents().strip() or None,
+        }
+
+        location_street = response.find('span', {'class': 'address-line2'}).decode_contents().strip() or None
+        #contact_name = profil.find('span', {'class': 'address-line1'}).decode_contents().strip() or None
+        location_plz = response.find('span', {'class': 'postal-code'}).decode_contents().strip() or None
+        location_ort = response.find('span', {'class': 'locality'}).decode_contents().strip() or None
+        location_country = response.find('span', {'class': 'country'}).decode_contents().strip() or None
+
+        parsed_object['post_struct'] = {
+            'title': self.clean_string(parsed_object['title']) or None,
+            'categories': self.clean_string(parsed_object['categories']) or None,
+            'location': {
+                'country': self.clean_string(location_country) or None,
+                'zipcode': self.clean_string(location_plz) or None,
+                'city': self.clean_string(location_ort) or None,
+                'street': self.clean_string(location_street) or None,
+            },
+            'task': self.clean_string(parsed_object['task']) or None,
+            'target_group': None,
+            'timing': self.clean_string(parsed_object['timing']) or None,
+            'effort': self.clean_string(parsed_object['effort']) or None,
+            'opportunities': None,
+            'organization': {
+                'name': self.clean_string(parsed_object['organization']) or None,
+                'zipcode': None,
+                'city': None,
+                'street': None,
+                'phone': None,
+                'email': None,
+            },
+            'contact': None,
+            'link': self.clean_string(parsed_object['link']) or None,
+            'source': self.clean_string(parsed_object['source']) or None,
+            'geo_location': None,
+            'requirements': self.clean_string(parsed_object['requirements']) or None,
+        }
+
+
+        return parsed_object
+
+    def add_urls(self):
+        """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape"""
+
+        import time
+
+        search_page_url = f'{self.base_url}/de/suche/ort?geo%5Bvalue%5D=10&geo%5Bsource_configuration%5D%5Borigin_address%5D=&last_minute=All&unterkunft=All&anbieter=&page=0'
+        next_page_url = search_page_url
+
+        index = 1
+        while next_page_url:
+
+            response = self.soupify_post(next_page_url, {
+                'ep-sortfilter': 1,
+                'ep-numperpage': 50,
+                'ep-sortorder': 'alpha'
+            })
+
+            # Get tags of individual results
+            detail_link_tags = [x.find('a') for x in response.find_all('div', {'class': 'field field--name-title field--type-string field--label-hidden'})]
+
+            # Get maximum number of pages
+            index_max = 9 #response.find('div', {'class': 'pager__item'}).findNext('a').decode_contents().strip()
+
+            if self.debug:
+                print(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+
+            # Iterate links and add, if not already found
+            for link_tag in detail_link_tags:
+                current_link = self.base_url + link_tag['href']
+                if current_link in self.urls:
+                    self.add_error({
+                        'func': 'add_urls',
+                        'body': {
+                            'page_index': index,
+                            'search_page': next_page_url,
+                            'duplicate_link': current_link,
+                            'duplicate_index': self.urls.index(current_link),
+                        }
+                    })
+                else:
+                    self.urls.append(current_link)
+
+            # Get next result page
+            next_page_url = response.find('li', {'class': 'pager__item pager__item--next'}).find('a')
+            if next_page_url:
+                next_page_url = self.base_url + '/de/suche/ort' + next_page_url['href']
+
+            index += 1
+
+            if index > 2:
+                break
+            time.sleep(self.delay)

--- a/etl/data_extraction/scraper/ein-jahr-freiwillig.py
+++ b/etl/data_extraction/scraper/ein-jahr-freiwillig.py
@@ -39,7 +39,7 @@ class Ein_Jahr_Freiwillig(Scraper):
             'timing': timing.find('div', {'class': 'field__item'}).decode_contents().strip() if timing is not None else None,
             'effort': effort.find('div', {'class': 'field__item'}).decode_contents().strip() if effort is not None else None,
             'opportunities': None,
-            'organization': organization.find_all('div')[1].decode_contents().strip() if organization is not None else None,
+            'organization': organization.find("a").decode_contents().strip() if organization is not None else None,
             'contact': None,
             'link': url or None,
             'source': self.base_url,

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -3,7 +3,7 @@ from data_extraction.Scraper import Scraper
 import re
 import math
 
-class Ein_Jahr_Freiwillig(Scraper):
+class EinJahrFreiwillig(Scraper):
     """Scrapes the website ein-jahr-freiwillig.de."""
 
     base_url = 'https://ein-jahr-freiwillig.de'
@@ -139,5 +139,8 @@ class Ein_Jahr_Freiwillig(Scraper):
                 next_page_url = self.base_url + '/de/suche/ort' + next_page_url.find('a')['href']
 
             index += 1
+
+            if index > 50:
+                break
 
             time.sleep(self.delay)

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -16,7 +16,7 @@ class EinJahrFreiwillig(Scraper):
         content = response.find('div', {'class': 'node__content'})
 
         location = content.find('p', {'class': 'address'})
-        task = content.find('div', {'class ': 'clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item'})
+        task = content.find('div', {'class': 'clearfix text-formatted field field--name-body field--type-text-with-summary field--label-hidden field__item'})
         timing = content.find('div', {'class': 'field field--name-field-field-verfuegbar-ab field--type-string field--label-above'})
         effort = content.find('div', {'class': 'field field--name-field-laenge-dienstzeit field--type-string field--label-above'})
         organization = content.find('div', {'class': 'field field--name-field-traeger field--type-entity-reference field--label-above'})

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -140,7 +140,4 @@ class EinJahrFreiwillig(Scraper):
 
             index += 1
 
-            if index > 50:
-                break
-
             time.sleep(self.delay)

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -3,6 +3,7 @@ from data_extraction.Scraper import Scraper
 import re
 import math
 
+
 class EinJahrFreiwillig(Scraper):
     """Scrapes the website ein-jahr-freiwillig.de."""
 
@@ -21,12 +22,19 @@ class EinJahrFreiwillig(Scraper):
         organization = content.find('div', {'class': 'field field--name-field-traeger field--type-entity-reference field--label-above'})
         prerequisits = content.find('div', {'class': 'field field--name-field-voraussetzungen field--type-string-long field--label-above'})
 
-        categories = content.find('div', {'class': 'field field--name-field-einsatzfelder field--type-entity-reference field--label-hidden field__items'})
         category_names = []
+        categories = content.find('div', {'class': 'field field--name-field-einsatzfelder field--type-entity-reference field--label-hidden field__items'})
         if categories is not None:
             categories = categories.find_all('a')
             for category in categories:
                 category_names.append(category.decode_contents().strip())
+
+        # Service types are added as an additional tag
+        service_types = content.find('div', {'class': 'field field--name-field-dienstarten field--type-entity-reference field--label-hidden field__items'})
+        if service_types is not None:
+            service_types = service_types.find_all('a')
+            for service_type in service_types:
+                category_names.append(service_type.decode_contents().strip())
 
         parsed_object = {
             'title': response.find('span', {'class': 'field field--name-title field--type-string field--label-hidden'}).decode_contents().strip() or None,
@@ -103,7 +111,6 @@ class EinJahrFreiwillig(Scraper):
 
         index = 1
         while next_page_url:
-
             response = self.soupify(next_page_url)
 
             # Get tags of individual results


### PR DESCRIPTION
Crawler implementation for ein-jahr-freiwillig.de

Can be tested with the following commands:

```
$ cd etl
$ python (or python3)
>>> from data_extraction.scraper.ein_jahr_freiwillig import EinJahrFreiwillig as scr
>>> i = scr('test')
>>> i.add_urls()

>>> i.crawl(i.urls[0], 1)
>>> i.data
```