### PR TITLE
237/add crawler for bundesfreiwilligendienst.de

### DIFF
--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -20,6 +20,7 @@
             <li><a href="https://www.gute-tat.de/" target="_blank" rel="noopener">www.gute-tat.de</a></li>
             <li><a href="https://www.weltwaerts.de" target="_blank" rel="noopener">www.weltwaerts.de</a></li>
             <li><a href="https://ein-jahr-freiwillig.de" target="_blank" rel="noopener">www.ein-jahr-freiwillig.de</a></li>
+            <li><a href="https://www.bundesfreiwilligendienst.de" target="_blank" rel="noopener">www.bundesfreiwilligendienst.de</a></li>
           </ul>
           <p>
             <br />

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -23,7 +23,7 @@ class Enhancer:
             'gutetat_hamburg': self.__enhance_gute_tat,
             'gutetat_munich': self.__enhance_gute_tat,
             'ein_jahr_freiwillig': self.__enhance_ein_jahr_freiwillig,
-
+            'bundesfreiwilligendienst': self.__enhance_bundesfreiwilligendienst,
         }
 
     def run(self):
@@ -58,3 +58,8 @@ class Enhancer:
     def __enhance_ein_jahr_freiwillig(self):
         """ domain specific enhancement for ein-jahr-freiwillig """
         e_tags.run(self.__data, self.__domain_name)
+
+    def __enhance_bundesfreiwilligendienst(self):
+        """ domain specific enhancement for bundesfreiwilligendienst """
+        e_tags.run(self.__data, self.__domain_name)
+

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -106,8 +106,21 @@ class Scraper:
         """Executes POST-request with the given url and form data, transforms it to a BeautifulSoup object and returns it."""
 
         res = requests.post(url, data=form_data)
+
         page = BeautifulSoup(res.text, 'html.parser')
         return page
+
+    @staticmethod
+    def soupify_post_session(url, form_data, session):
+        """Executes POST-request with the given url, form data and session, transforms it to a BeautifulSoup object and returns it."""
+
+        if session is None:
+            session = requests.Session()
+
+        res = session.post(url, data=form_data)
+
+        page = BeautifulSoup(res.text, 'html.parser')
+        return page, session
 
     @staticmethod
     def parse(response, url):

--- a/etl/data_extraction/scrape_data.py
+++ b/etl/data_extraction/scrape_data.py
@@ -50,8 +50,6 @@ def run():
     """Starts a thread with the execute_scraper function for all overridden scraper subclasses in /data_extraction/scraper."""
 
     for file_entry in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/scraper')):
-        if file_entry.name != 'bundesfreiwilligendienst.py':
-            continue
 
         if file_entry.is_file():
             scraper_module_name = os.path.splitext(

--- a/etl/data_extraction/scrape_data.py
+++ b/etl/data_extraction/scrape_data.py
@@ -50,6 +50,8 @@ def run():
     """Starts a thread with the execute_scraper function for all overridden scraper subclasses in /data_extraction/scraper."""
 
     for file_entry in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/scraper')):
+        if file_entry.name != 'bundesfreiwilligendienst.py':
+            continue
 
         if file_entry.is_file():
             scraper_module_name = os.path.splitext(

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -37,6 +37,8 @@ class BundesFreiwilligendienst(Scraper):
             'location': location.decode_contents().strip() if location is not None else None,
             'task': task.decode_contents().strip() if task is not None else None,
             'target_group': None,
+            'prerequisites': None,
+            'language_skills': None,
             'timing': None,
             'effort': None,
             'opportunities': None,
@@ -48,8 +50,6 @@ class BundesFreiwilligendienst(Scraper):
                 'lat': lat,
                 'lon': lon,
             } if lat and lon else None, # If longitude and latitude are None, geo_location is set to None,
-            'languages': None,
-            'requirements': None,
 
         }
         location_street = None

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -1,0 +1,140 @@
+from data_extraction.Scraper import Scraper
+import re
+import math
+
+class BundesFreiwilligendienst(Scraper):
+
+    base_url = "https://www.bundesfreiwilligendienst.de"
+    debug = True
+
+    def parse(self, response, url):
+
+        content = response.find('div', {'class': 'tx-bfd-einsatzstellensuche'})
+
+        title = content.find('div', {'class': 'span12'})
+        categories = content.find('table', {'class': 'platzangebote table table-striped'})
+        location = content.find('div', {'class': 'span5'}).find_all('div', {'class': 'box white-bg'})[0]
+        task = content.find('div', {'class': 'description'})
+        contact = content.find('div', {'class': 'span5'}).find_all('div', {'class': 'box white-bg'})[1].find('div', {'class': 'box-content'})
+
+
+
+
+
+        parsed_object = {
+            'title': title.find('h1').decode_contents().strip() if title is not None else None,
+            'categories': categories.find('tbody').find('tr').find_all('td')[1].find('li').decode_contents().strip() if categories is not None else None,
+            'location': location.decode_contents().strip() if location is not None else None,
+            'task': task.decode_contents().strip() if task is not None else None,
+            'target_group': None,
+            'timing': None,
+            'effort': None,
+            'opportunities': None,
+            'organization': None,
+            'contact': contact.decode_contents().strip() if contact is not None else None,
+            'link': url or None,
+            'source': self.base_url,
+            'geo_location': None,
+            'languages': None,
+            'requirements': None,
+
+        }
+
+        location_street = location.find_all('div', {'class': 'span12'})[0].find('div', {'class': 'span10'})
+        location_plz = location.find_all('div', {'class': 'span12'})[1].find('span', {'class': 'span10'})
+        location_ort = location.find_all('div', {'class': 'span12'})[2].find('span', {'class': 'span10'})
+
+        contact_name = contact.find_all('div', {'class': 'span12'})[0].find('div', {'class': 'span10'})
+        contact_phone = contact.find_all('div', {'class': 'span12'})[1].find('span', {'class': 'span10'})
+        contact_email = contact.find_all('div', {'class': 'span12'})[2].find('span', {'class': 'span10'}).find('a')
+
+        parsed_object['post_struct'] = {
+            'title': self.clean_string(parsed_object['title']) or None,
+            'categories': parsed_object['categories'] or None,
+            'location': {
+                'country': None,
+                'zipcode': self.clean_string(location_plz.decode_contents()) if location_plz is not None else None,
+                'city': self.clean_string(location_ort.decode_contents()) if location_ort is not None else None,
+                'street': self.clean_string(location_street.decode_contents()) if location_street is not None else None,
+            },
+            'task': self.clean_string(parsed_object['task']) or None,
+            'target_group': None,
+            'prerequisites': None,
+            'language_skills': None,
+            'timing': None,
+            'effort': None,
+            'opportunities': None,
+            'organization': {
+                'name':  None,
+                'zipcode': None,
+                'city': None,
+                'street': None,
+                'phone': None,
+                'email': None,
+            },
+            'contact': {
+                'name': self.clean_string(contact_name.decode_contents().strip()) if contact_name is not None else None,
+                'zipcode': None,
+                'city': None,
+                'street': None,
+                'phone': self.clean_string(contact_phone.decode_contents().strip()) if contact_phone is not None else None,
+                'email': self.clean_string(contact_email.decode_contents().strip()) if contact_email is not None else None,
+            },
+            'link': self.clean_string(parsed_object['link']) or None,
+            'source': self.clean_string(parsed_object['source']) or None,
+            'geo_location': None,
+        }
+
+        return parsed_object
+
+
+    def add_urls(self):
+
+        import time
+
+        search_page_url = f'{self.base_url}/bundesfreiwilligendienst/platz-einsatzstellensuche/einsatzstelle-suchen.html?tx_bfdeinsatzstellensuche_einsatzstellensuche%5Baction%5D=liste&tx_bfdeinsatzstellensuche_einsatzstellensuche%5Bcontroller%5D=Suchen%5CEinsatzstellensuche&cHash=ff2107f5ca1fc1b5b392cc09ff84a3c3'
+        next_page_url = search_page_url
+
+        index = 1
+
+        while next_page_url:
+
+            response = self.soupify(next_page_url)
+
+            detail_link_tags = [x.find('a') for x in response.find_all('td', {'class': 'row5'})]
+            #detail_link_tags = list(filter(lambda x: x['href'].startswith('/was-du-tun-kannst/deine-moeglichkeiten/ehrenamt-finden/detail.html?'), detail_link_tags))
+            print(detail_link_tags)
+
+            # Get maximum number of pages
+            index_max = response.find('ul', {'class': 'pagination'}).find_all('li')[8].find('a').decode_contents().strip()
+
+            if self.debug:
+                print(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+
+            # Iterate links and add, if not already found
+            for link_tag in detail_link_tags:
+                current_link = self.base_url + "/" + link_tag['href']
+                if current_link in self.urls:
+                    self.add_error({
+                        'func': 'add_urls',
+                        'body': {
+                            'page_index': index,
+                            'search_page': next_page_url,
+                            'duplicate_link': current_link,
+                            'duplicate_index': self.urls.index(current_link),
+                        }
+                    })
+                else:
+                    self.urls.append(current_link)
+
+                # Get next result page
+                next_page_url = index_max = response.find('ul', {'class': 'pagination'}).find_all('li')[9]
+                if next_page_url:
+                    next_page_url = self.base_url + '/' + next_page_url.find('a')['href']
+
+                index += 1
+
+                if index > 3:
+                    break
+
+                time.sleep(self.delay)

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -170,7 +170,4 @@ class BundesFreiwilligendienst(Scraper):
 
             index += 1
 
-            if index > 1:
-                break
-
             time.sleep(self.delay)

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -2,11 +2,14 @@ from data_extraction.Scraper import Scraper
 
 
 class BundesFreiwilligendienst(Scraper):
+    """Scrapes the website bundesfreiwilligendienst.de."""
 
     base_url = "https://www.bundesfreiwilligendienst.de"
     debug = True
 
     def parse(self, response, url):
+        """Handles the soupified response of a detail page in the predefined way and returns it."""
+
         content = response.find('div', {'class': 'single_view_entry clearfix'})
 
         title = content.find('h1')
@@ -50,8 +53,8 @@ class BundesFreiwilligendienst(Scraper):
                 'lat': lat,
                 'lon': lon,
             } if lat and lon else None, # If longitude and latitude are None, geo_location is set to None,
-
         }
+
         location_street = None
         location_zipcode = None
         location_city = None
@@ -73,6 +76,7 @@ class BundesFreiwilligendienst(Scraper):
             object_name = contact_entry.find('strong').decode_contents().strip()
             if 'Name' in object_name:
                 contact_name = contact_entry.find('div', {'class': 'span10'})
+                # Due to the contact name containing lots of spaces, they are being removed using split and join
                 contact_name = ' '.join(contact_name.decode_contents().strip().split()) if contact_name is not None else None
             if 'Telefon' in object_name:
                 contact_phone = contact_entry.find('span', {'class': 'span10'})
@@ -113,12 +117,14 @@ class BundesFreiwilligendienst(Scraper):
             },
             'link': self.clean_string(parsed_object['link']) or None,
             'source': self.clean_string(parsed_object['source']) or None,
-            'geo_location': None,
+            'geo_location': parsed_object['geo_location'],
+            'map_address': None,
         }
 
         return parsed_object
 
     def add_urls(self):
+        """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape."""
 
         import time
 
@@ -169,5 +175,8 @@ class BundesFreiwilligendienst(Scraper):
                 next_page_url = self.base_url + '/' + next_page_url.parent['href']
 
             index += 1
+
+            if index > 10:
+                break
 
             time.sleep(self.delay)

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -1,6 +1,5 @@
 from data_extraction.Scraper import Scraper
-import re
-import math
+
 
 class BundesFreiwilligendienst(Scraper):
 
@@ -8,22 +7,33 @@ class BundesFreiwilligendienst(Scraper):
     debug = True
 
     def parse(self, response, url):
+        content = response.find('div', {'class': 'single_view_entry clearfix'})
 
-        content = response.find('div', {'class': 'tx-bfd-einsatzstellensuche'})
+        title = content.find('h1')
+        categories_tag = content.find('section', {'class': 'einsatzbereich'})
 
-        title = content.find('div', {'class': 'span12'})
-        categories = content.find('table', {'class': 'platzangebote table table-striped'})
+        categories = []
+        if categories_tag is not None:
+            for cat_entry_lst in categories_tag.find('div', {'class': 'span9'}).find_all('li'):
+                for cat_entry in cat_entry_lst.decode_contents().split(','):
+                    categories.append(cat_entry.strip())
+
         location = content.find('div', {'class': 'span5'}).find_all('div', {'class': 'box white-bg'})[0]
         task = content.find('div', {'class': 'description'})
         contact = content.find('div', {'class': 'span5'}).find_all('div', {'class': 'box white-bg'})[1].find('div', {'class': 'box-content'})
 
+        lat = None
+        lon = None
 
-
-
+        try:
+            lat = float(response.find('span', {'class': 'coordLat'}).decode_contents().strip()) if response.find('span', {'class': 'coordLat'}) else None
+            lon = float(response.find('span', {'class': 'coordLong'}).decode_contents().strip()) if response.find('span', {'class': 'coordLong'}) else None
+        except (TypeError, ValueError):
+            pass
 
         parsed_object = {
-            'title': title.find('h1').decode_contents().strip() if title is not None else None,
-            'categories': categories.find('tbody').find('tr').find_all('td')[1].find('li').decode_contents().strip() if categories is not None else None,
+            'title': title.decode_contents().strip() if title is not None else None,
+            'categories':  categories,
             'location': location.decode_contents().strip() if location is not None else None,
             'task': task.decode_contents().strip() if task is not None else None,
             'target_group': None,
@@ -34,27 +44,47 @@ class BundesFreiwilligendienst(Scraper):
             'contact': contact.decode_contents().strip() if contact is not None else None,
             'link': url or None,
             'source': self.base_url,
-            'geo_location': None,
+            'geo_location':  {
+                'lat': lat,
+                'lon': lon,
+            } if lat and lon else None, # If longitude and latitude are None, geo_location is set to None,
             'languages': None,
             'requirements': None,
 
         }
+        location_street = None
+        location_zipcode = None
+        location_city = None
 
-        location_street = location.find_all('div', {'class': 'span12'})[0].find('div', {'class': 'span10'})
-        location_plz = location.find_all('div', {'class': 'span12'})[1].find('span', {'class': 'span10'})
-        location_ort = location.find_all('div', {'class': 'span12'})[2].find('span', {'class': 'span10'})
+        for location_entry in location.find_all('div', {'class': 'span12'}):
+            object_name = location_entry.find('strong').decode_contents().strip()
+            if 'Straße' in object_name:
+                location_street = location_entry.find('div', {'class': 'span10'})
+            if 'PLZ' in object_name:
+                location_zipcode = location_entry.find('span', {'class': 'span10'})
+            if 'Ort' in object_name:
+                location_city = location_entry.find('span', {'class': 'span10'})
 
-        contact_name = contact.find_all('div', {'class': 'span12'})[0].find('div', {'class': 'span10'})
-        contact_phone = contact.find_all('div', {'class': 'span12'})[1].find('span', {'class': 'span10'})
-        contact_email = contact.find_all('div', {'class': 'span12'})[2].find('span', {'class': 'span10'}).find('a')
+        contact_name = None
+        contact_phone = None
+        contact_email = None
+
+        for contact_entry in contact.find_all('div', {'class': 'span12'}):
+            object_name = contact_entry.find('strong').decode_contents().strip()
+            if 'Name' in object_name:
+                contact_name = contact_entry.find('div', {'class': 'span10'})
+            if 'Telefon' in object_name:
+                contact_phone = contact_entry.find('span', {'class': 'span10'})
+            if 'Mail' in object_name:
+                contact_email = contact_entry.find('span', {'class': 'span10'}).find('a')
 
         parsed_object['post_struct'] = {
             'title': self.clean_string(parsed_object['title']) or None,
             'categories': parsed_object['categories'] or None,
             'location': {
                 'country': None,
-                'zipcode': self.clean_string(location_plz.decode_contents()) if location_plz is not None else None,
-                'city': self.clean_string(location_ort.decode_contents()) if location_ort is not None else None,
+                'zipcode': self.clean_string(location_zipcode.decode_contents()) if location_zipcode is not None else None,
+                'city': self.clean_string(location_city.decode_contents()) if location_city is not None else None,
                 'street': self.clean_string(location_street.decode_contents()) if location_street is not None else None,
             },
             'task': self.clean_string(parsed_object['task']) or None,
@@ -87,29 +117,30 @@ class BundesFreiwilligendienst(Scraper):
 
         return parsed_object
 
-
     def add_urls(self):
 
         import time
 
-        search_page_url = f'{self.base_url}/bundesfreiwilligendienst/platz-einsatzstellensuche/einsatzstelle-suchen.html?tx_bfdeinsatzstellensuche_einsatzstellensuche%5Baction%5D=liste&tx_bfdeinsatzstellensuche_einsatzstellensuche%5Bcontroller%5D=Suchen%5CEinsatzstellensuche&cHash=ff2107f5ca1fc1b5b392cc09ff84a3c3'
+        search_page_url = f'{self.base_url}/bundesfreiwilligendienst/platz-einsatzstellensuche/einsatzstelle-suchen.html?tx_bfdeinsatzstellensuche_einsatzstellensuche%5Bseite%5D=1&tx_bfdeinsatzstellensuche_einsatzstellensuche%5Baction%5D=blaettern&tx_bfdeinsatzstellensuche_einsatzstellensuche%5Bcontroller%5D=Suchen%5CEinsatzstellensuche&cHash=094683ada8eb8c80aab0c200e3aa89f1'
         next_page_url = search_page_url
 
         index = 1
+        index_max = -1
 
         while next_page_url:
-
             response = self.soupify(next_page_url)
 
             detail_link_tags = [x.find('a') for x in response.find_all('td', {'class': 'row5'})]
-            #detail_link_tags = list(filter(lambda x: x['href'].startswith('/was-du-tun-kannst/deine-moeglichkeiten/ehrenamt-finden/detail.html?'), detail_link_tags))
-            print(detail_link_tags)
+
+            pagination = response.find('ul', {'class': 'pagination'})
+            next_page_tag = pagination.find('i', {'class': 'fa fa-chevron-right'})
 
             # Get maximum number of pages
-            index_max = response.find('ul', {'class': 'pagination'}).find_all('li')[8].find('a').decode_contents().strip()
+            if index_max == -1 and next_page_tag is not None:
+                index_max = next_page_tag.parent.parent.find_previous_sibling('li').a.decode_contents().strip()
 
             if self.debug:
-                print(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+                print(f'Fetched {len(detail_link_tags)} URLs from {self.base_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:
@@ -127,14 +158,12 @@ class BundesFreiwilligendienst(Scraper):
                 else:
                     self.urls.append(current_link)
 
-                # Get next result page
-                next_page_url = index_max = response.find('ul', {'class': 'pagination'}).find_all('li')[9]
-                if next_page_url:
-                    next_page_url = self.base_url + '/' + next_page_url.find('a')['href']
+            # Get next result page
+            next_page_url = next_page_tag
 
-                index += 1
+            if next_page_url:
+                next_page_url = self.base_url + '/' + next_page_url.parent['href']
 
-                if index > 3:
-                    break
+            index += 1
 
-                time.sleep(self.delay)
+            time.sleep(self.delay)

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -48,7 +48,7 @@ class BundesFreiwilligendienst(Scraper):
             'organization': None,
             'contact': contact.decode_contents().strip() if contact is not None else None,
             'link': url or None,
-            'source': self.base_url,
+            'source': 'www.bundesfreiwilligendienst.de',
             'geo_location':  {
                 'lat': lat,
                 'lon': lon,

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -73,6 +73,7 @@ class BundesFreiwilligendienst(Scraper):
             object_name = contact_entry.find('strong').decode_contents().strip()
             if 'Name' in object_name:
                 contact_name = contact_entry.find('div', {'class': 'span10'})
+                contact_name = ' '.join(contact_name.decode_contents().strip().split()) if contact_name is not None else None
             if 'Telefon' in object_name:
                 contact_phone = contact_entry.find('span', {'class': 'span10'})
             if 'Mail' in object_name:
@@ -103,7 +104,7 @@ class BundesFreiwilligendienst(Scraper):
                 'email': None,
             },
             'contact': {
-                'name': self.clean_string(contact_name.decode_contents().strip()) if contact_name is not None else None,
+                'name': self.clean_string(contact_name) if len(contact_name) > 0 else None,
                 'zipcode': None,
                 'city': None,
                 'street': None,
@@ -168,5 +169,8 @@ class BundesFreiwilligendienst(Scraper):
                 next_page_url = self.base_url + '/' + next_page_url.parent['href']
 
             index += 1
+
+            if index > 1:
+                break
 
             time.sleep(self.delay)

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -176,7 +176,4 @@ class BundesFreiwilligendienst(Scraper):
 
             index += 1
 
-            if index > 10:
-                break
-
             time.sleep(self.delay)


### PR DESCRIPTION
Crawler implementation for bundesfreiwilligendienst.de

Can be tested with the following commands:

```
$ cd etl
$ python (or python3)
>>> from shared.utils import write_data_to_json
>>> write_data_to_json('data_extraction/data/test.json', [])

>>> from data_extraction.scraper.bundesfreiwilligendienst import BundesFreiwilligendienst as scr
>>> i = scr('test')
>>> i.add_urls()

>>> import random
>>> for j in range(0, 20):
...    i.crawl(i.urls[j], random.randrange(len(i.urls)))
```