### PR TITLE
209/improve logging capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 etl/**/*.json
 etl/**/*.csv
 etl/**/*.log
+etl/logs

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -59,13 +59,13 @@ class Enhancer:
         """ domain specific enhancement for weltwaerst """
         self.logger.debug("__enhance_weltwaerts()")
 
-        pass
+        self.logger.info("no specific enhancement for weltwaerst required")
 
     def __enhance_gute_tat(self):
         """ domain specific enhancement for gute-tat website group"""
         self.logger.debug("__enhance_gute_tat()")
 
-        pass
+        self.logger.info("no specific enhancement for gute-tat required")
 
     def __enhance_ein_jahr_freiwillig(self):
         """ domain specific enhancement for ein-jahr-freiwillig """

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -1,7 +1,7 @@
-from .enhancement_duplicates import enhancement_exact_duplicates as e_exact_duplicates
-from .enhancement_tags import enhancement_tags as e_tags
-from .enhancement_location import enhancement_location as e_location
-from .enhancement_location.lat_lon_enhancer import add_lat_lon
+from data_enhancement.enhancement_duplicates import enhancement_exact_duplicates as e_exact_duplicates
+from data_enhancement.enhancement_tags import enhancement_tags as e_tags
+from data_enhancement.enhancement_location import enhancement_location as e_location
+from data_enhancement.enhancement_location.lat_lon_enhancer import add_lat_lon
 from shared.LoggerFactory import LoggerFactory
 
 
@@ -41,12 +41,13 @@ class Enhancer:
 
     def __run_for_domain(self, domain):
         """ run domainspecific enhancement. """
-        self.logger.debug(f"Run domain specific enhancement enhancement for {domain}")
+        self.logger.debug("__run_for_domain()")
+        self.logger.info(f"Run domain specific enhancement enhancement for {domain}")
 
         if domain in self.__function_map:
             self.__function_map[domain]()
         else:
-            self.logger.error(f"Error [enhance_data.py]: No function set for '{domain}'")
+            self.logger.error(f"No function set for '{domain}'")
 
     def __enhance_ehrenamt_hessen(self):
         """ domain specific enhancement for ehrenamtsuche hessen """

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -2,6 +2,7 @@ from .enhancement_duplicates import enhancement_exact_duplicates as e_exact_dupl
 from .enhancement_tags import enhancement_tags as e_tags
 from .enhancement_location import enhancement_location as e_location
 from .enhancement_location.lat_lon_enhancer import add_lat_lon
+from shared.LoggerFactory import LoggerFactory
 
 
 class Enhancer:
@@ -10,6 +11,7 @@ class Enhancer:
     def __init__(self, data, domain_name):
         self.__data = data
         self.__domain_name = domain_name
+        self.logger = LoggerFactory.get_enhancement_logger()
 
         # link function containing domain specific enhancement to said domain here
         # 'domain' : self.__enhance_domain_function_name
@@ -28,7 +30,9 @@ class Enhancer:
 
     def run(self):
         """ run general enhancements and load domainspecific enhancement. """
-        print(f"Run general enhancement enhancement for {self.__domain_name}")
+        self.logger.debug("run()")
+        self.logger.info(f"Run general enhancement enhancement for {self.__domain_name}")
+
         e_exact_duplicates.remove_duplicates(self.__data)
         e_location.add_map_address(self.__data)
         add_lat_lon(self.__data)
@@ -37,24 +41,33 @@ class Enhancer:
 
     def __run_for_domain(self, domain):
         """ run domainspecific enhancement. """
-        print(f"Run domain specific enhancement enhancement for {domain}")
+        self.logger.debug(f"Run domain specific enhancement enhancement for {domain}")
+
         if domain in self.__function_map:
             self.__function_map[domain]()
         else:
-            print(f"Error [enhance_data.py]: No function set for '{domain}'")
+            self.logger.error(f"Error [enhance_data.py]: No function set for '{domain}'")
 
     def __enhance_ehrenamt_hessen(self):
         """ domain specific enhancement for ehrenamtsuche hessen """
+        self.logger.debug("__enhance_ehrenamt_hessen()")
+
         e_tags.run(self.__data, self.__domain_name)
 
     def __enhance_weltwaerts(self):
         """ domain specific enhancement for weltwaerst """
+        self.logger.debug("__enhance_weltwaerts()")
+
         pass
 
     def __enhance_gute_tat(self):
         """ domain specific enhancement for gute-tat website group"""
+        self.logger.debug("__enhance_gute_tat()")
+
         pass
 
     def __enhance_ein_jahr_freiwillig(self):
         """ domain specific enhancement for ein-jahr-freiwillig """
+        self.logger.debug("__enhance_ein_jahr_freiwillig()")
+
         e_tags.run(self.__data, self.__domain_name)

--- a/etl/data_enhancement/enhance_data.py
+++ b/etl/data_enhancement/enhance_data.py
@@ -75,5 +75,7 @@ class Enhancer:
 
     def __enhance_bundesfreiwilligendienst(self):
         """ domain specific enhancement for bundesfreiwilligendienst """
+        self.logger.debug("__enhance_bundesfreiwilligendienst()")
+
         e_tags.run(self.__data, self.__domain_name)
 

--- a/etl/data_enhancement/enhancement_duplicates/JsonPost.py
+++ b/etl/data_enhancement/enhancement_duplicates/JsonPost.py
@@ -1,8 +1,11 @@
 from copy import deepcopy
+from shared.LoggerFactory import LoggerFactory
 
 
 class JsonPost:
     """Handles the data to find duplicates."""
+
+    logger = LoggerFactory.get_enhancement_logger()
 
     def __init__(self, json):
         """Constructor of JsonPost."""
@@ -14,6 +17,7 @@ class JsonPost:
     @staticmethod
     def __remove_not_needed_data(json):
         """Removes data from json which should not be use in the comparison."""
+        JsonPost.logger.debug("__remove_not_needed_data()")
 
         if 'link' in json:
             del json['link']

--- a/etl/data_enhancement/enhancement_duplicates/enhancement_exact_duplicates.py
+++ b/etl/data_enhancement/enhancement_duplicates/enhancement_exact_duplicates.py
@@ -1,12 +1,13 @@
 from data_enhancement.enhancement_duplicates.JsonPost import JsonPost
+from shared.LoggerFactory import LoggerFactory
 
-
-debug = False
+logger = LoggerFactory.get_enhancement_logger()
 
 
 def remove_duplicates(data):
     """Removes exact duplicates from the json list.
     The URL is ignored in the comparison."""
+    logger.debug("remove_duplicates()")
 
     posts_by_title = {}
     duplicates = []
@@ -23,18 +24,18 @@ def remove_duplicates(data):
             continue
         __one_to_one_comparison(posts, duplicates)
 
-    print(f'[INFO]\tFound {len(duplicates)} duplicates')
+    logger.info(f'Found {len(duplicates)} duplicates')
 
     for duplicate in duplicates:
-        if debug:
-            print(f'[DEBUG]\t\'{duplicate["title"]}\' is a duplicate')
+        logger.debug(f'\'{duplicate["title"]}\' is a duplicate')
         data.remove(duplicate)
 
-    print(f'[INFO]\tRemoved {len(duplicates)} duplicates')
+    logger.info(f'Removed {len(duplicates)} duplicates')
 
 
 def __one_to_one_comparison(posts, duplicates):
     """Makes a one to one comparison between all JsonPosts in a list."""
+    logger.debug("__one_to_one_comparison()")
 
     for i in range(0, len(posts)):
         for j in range(i + 1, len(posts)):

--- a/etl/data_enhancement/enhancement_location/enhancement_location.py
+++ b/etl/data_enhancement/enhancement_location/enhancement_location.py
@@ -1,4 +1,10 @@
+from shared.LoggerFactory import LoggerFactory
+
+logger = LoggerFactory.get_enhancement_logger()
+
 def add_map_address(data):
     """ dummy function for adding map_adress """
+    logger.debug("add_map_address()")
+
     for post in data:
         post['post_struct']['map_address'] = ''

--- a/etl/data_enhancement/enhancement_tags/enhancement_tags.py
+++ b/etl/data_enhancement/enhancement_tags/enhancement_tags.py
@@ -2,20 +2,26 @@ import csv
 import os
 
 from shared.utils import write_data_to_json
+from shared.LoggerFactory import LoggerFactory
 
 ROOT_DIR = os.environ['ROOT_DIR']
+logger = LoggerFactory.get_enhancement_logger()
 
 
 def run(data, domain):
     """ calls functions for extracting and ranking tags """
+    logger.debug("run()")
+
     find_new_tags(data, domain)
     rank_tags(data, domain)
 
 
 def load_tags_from_file():
     """loads given tags from csv file and returns them in a dict"""
+    logger.debug("load_tags_from_file()")
+
     loaded_tags = {}
-    print("load_tags_from_file - path: ",os.path.join(ROOT_DIR,'data_enhancement', 'Tags-einander-helfen.csv'))
+    logger.info(f"load_tags_from_file - path: {os.path.join(ROOT_DIR,'data_enhancement', 'Tags-einander-helfen.csv')}")
     with open(os.path.join(ROOT_DIR, 'data_enhancement','Tags-einander-helfen.csv'), newline='',
               encoding='utf-8') as csvfile:
         reader = csv.DictReader(csvfile, delimiter=';')
@@ -26,6 +32,8 @@ def load_tags_from_file():
 
 def get_synonyms_as_list(values):
     """converts the synonyms to a list"""
+    logger.debug("get_synonyms_as_list()")
+
     synonyms = []
     for val in values:
         for syn in val:
@@ -36,6 +44,8 @@ def get_synonyms_as_list(values):
 def find_new_tags(file,domain):
     """scans categories of crawled data to find tags not existing in the given csv
     writes new found tags to output directory as new_tags.json"""
+    logger.debug("find_new_tags()")
+
     loaded_tags = load_tags_from_file()
     synonyms = get_synonyms_as_list(loaded_tags.values())
 
@@ -53,6 +63,8 @@ def rank_tags(file, domain):
     # todo: find occurrences of synonyms and add to label count,
     #       print to json file in the same format like the tag ontology csv file,
     #       make a new index for the ranked tag ontology for frontend access
+    logger.debug("rank_tags()")
+
     loaded_tags = load_tags_from_file()
     labels = loaded_tags.keys()
     synonyms = get_synonyms_as_list(loaded_tags.values())

--- a/etl/data_enhancement/enhancement_tags/enhancement_tags.py
+++ b/etl/data_enhancement/enhancement_tags/enhancement_tags.py
@@ -41,7 +41,7 @@ def get_synonyms_as_list(values):
     return synonyms
 
 
-def find_new_tags(file,domain):
+def find_new_tags(file, domain):
     """scans categories of crawled data to find tags not existing in the given csv
     writes new found tags to output directory as new_tags.json"""
     logger.debug("find_new_tags()")

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -66,8 +66,8 @@ class Scraper:
         crawling_time = str((time.time() - self.start))
         crawling_time = "{:.2f}".format((time.time() - self.start))
         ProgressBar.add_time(self.name, crawling_time)
-        self.logger.info(f"[{self.name}] took {crawling_time} seconds to crawl {len(self.urls)}"
-                         f" pages from {self.base_url}")
+        self.logger.debug(f"[{self.name}] took {crawling_time} seconds to crawl {len(self.urls)}"
+                          f" pages from {self.base_url}")
 
     def crawl(self, url, index):
         """Crawls page, runs the parse function over the GET-result and appends it to the existing data output file."""

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -84,7 +84,6 @@ class Scraper:
             self.logger.exception(f'fn : parse, body {str(err)}, index: {index}, url:{url}')
 
         self.logger.debug(f'[{self.name}] Scraping page #{index} ended')
-        #ProgressBar.get_progress_data(self.name, index, len(self.urls), ProgressBar.MODE_CRAWLING)
         self.get_progress_data_crawling(index, len(self.urls))
 
     def soupify(self, url):

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -81,7 +81,7 @@ class Scraper:
             self.logger.exception(f'fn : parse, body {str(err)}, index: {index}, url:{url}')
 
         self.logger.debug(f'[{self.name}] Scraping page #{index} ended')
-        print("\n" + ProgressBar.get_progress_data(self.name, index, len(self.urls)))
+        ProgressBar.get_progress_data(self.name, index, len(self.urls))
 
     def soupify(self, url):
         """Executes GET-request with the given url, transforms it to a BeautifulSoup object and returns it."""
@@ -115,13 +115,13 @@ class Scraper:
 
     def parse(self, response, url):
         """Transforms the soupified response of a detail page in a predefined way and returns it."""
-        self.logger.info("parse()")
+        self.logger.debug("parse()")
 
         return response.text
 
     def add_urls(self):
         """Adds URLs to an array which is later iterated over and scraped each."""
-        self.logger.info("add_urls()")
+        self.logger.debug("add_urls()")
 
         self.urls.append(self.base_url)
 

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -99,9 +99,10 @@ class Scraper:
         page = BeautifulSoup(res.text, 'html.parser')
         return page
 
-    @staticmethod
-    def soupify_post_session(url, form_data, session):
+
+    def soupify_post_session(self, url, form_data, session):
         """Executes POST-request with the given url, form data and session, transforms it to a BeautifulSoup object and returns it."""
+        self.logger.debug("soupify_post_session()")
 
         if session is None:
             session = requests.Session()

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -63,7 +63,10 @@ class Scraper:
             time.sleep(self.delay)
             self.crawl(url, i + 1)
 
-        self.logger.info(f"[{self.name}] took {(time.time() - self.start):0.2f} seconds to crawl {len(self.urls)}"
+        crawling_time = str((time.time() - self.start))
+        crawling_time = "{:.2f}".format((time.time() - self.start))
+        ProgressBar.add_time(self.name, crawling_time)
+        self.logger.info(f"[{self.name}] took {crawling_time} seconds to crawl {len(self.urls)}"
                          f" pages from {self.base_url}")
 
     def crawl(self, url, index):
@@ -81,7 +84,8 @@ class Scraper:
             self.logger.exception(f'fn : parse, body {str(err)}, index: {index}, url:{url}')
 
         self.logger.debug(f'[{self.name}] Scraping page #{index} ended')
-        ProgressBar.get_progress_data(self.name, index, len(self.urls))
+        #ProgressBar.get_progress_data(self.name, index, len(self.urls), ProgressBar.MODE_CRAWLING)
+        self.get_progress_data_crawling(index, len(self.urls))
 
     def soupify(self, url):
         """Executes GET-request with the given url, transforms it to a BeautifulSoup object and returns it."""
@@ -158,3 +162,15 @@ class Scraper:
             return None
 
         return BeautifulSoup(value, 'lxml').text
+
+    def get_progress_data_fetching(self, current, total):
+        """ Updates progress data of fetching process for crawler and triggers print of progeess bar"""
+        self.logger.debug("get_progress_data_fetching()")
+
+        ProgressBar.get_progress_data(self.name, current, total, ProgressBar.MODE_FETCHING)
+
+    def get_progress_data_crawling(self, current, total):
+        """ Updates progress data of crawling for crawler and triggers print of progeess bar"""
+        self.logger.debug("get_progress_data_fetching()")
+
+        ProgressBar.get_progress_data(self.name, current, total, ProgressBar.MODE_CRAWLING)

--- a/etl/data_extraction/Scraper.py
+++ b/etl/data_extraction/Scraper.py
@@ -81,7 +81,7 @@ class Scraper:
             self.logger.exception(f'fn : parse, body {str(err)}, index: {index}, url:{url}')
 
         self.logger.debug(f'[{self.name}] Scraping page #{index} ended')
-        LoggerFactory.get_general_logger().info("\n" + ProgressBar.get_progress_data(self.name, index, len(self.urls)))
+        print("\n" + ProgressBar.get_progress_data(self.name, index, len(self.urls)))
 
     def soupify(self, url):
         """Executes GET-request with the given url, transforms it to a BeautifulSoup object and returns it."""

--- a/etl/data_extraction/scrape_data.py
+++ b/etl/data_extraction/scrape_data.py
@@ -20,7 +20,7 @@ def execute_scraper(scraper_file_name: str):
     """Looks for the given file_name in the /data_extraction/scraper directory.
     Checks if the files contains a subclass of Scraper (/data_extraction/Scraper.py) and starts the run function.
     Writes the scraped data and errors during the scraping process data_extraction/data and data_extraction/errors."""
-
+    logger.debug("execute_scraper()")
     logger.info(f"execute_scraper for {scraper_file_name}")
     try:
         scraper_module = import_module(f'data_extraction.scraper.{scraper_file_name}')
@@ -32,19 +32,11 @@ def execute_scraper(scraper_file_name: str):
                 scraper_class = scraper_sub_class
 
         if not scraper_class:
-            logger.exception(f'[{scraper_file_name}] Error: No sub-class of class Scraper found')
             raise Exception(f'[{scraper_file_name}] Error: No sub-class of class Scraper found')
 
         # Create instance of the Scraper sub-class and execute the run method 
         scraper_instance = scraper_class(scraper_file_name)
         scraper_instance.run()
-
-        # Write the errors of the scraper to the data_extraction/errors directory
-        scraper_errors = scraper_instance.get_errors()
-        if len(scraper_errors):
-            time_stamp = get_current_timestamp()
-            write_data_to_json(os.path.join(ROOT_DIR, 'data_extraction/errors', f'{scraper_file_name}_{time_stamp}.log'),
-                               scraper_errors)
 
     except Exception as err:
         logger.exception(err)
@@ -53,7 +45,7 @@ def execute_scraper(scraper_file_name: str):
 def run():
     """Starts a thread with the execute_scraper function for all overridden scraper subclasses in
     /data_extraction/scraper."""
-
+    logger.debug("run()")
     for file_entry in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/scraper')):
 
         if file_entry.is_file():

--- a/etl/data_extraction/scrape_data.py
+++ b/etl/data_extraction/scrape_data.py
@@ -6,9 +6,11 @@ from inspect import getmembers, isclass
 
 from data_extraction.Scraper import Scraper
 from shared.utils import write_data_to_json, get_current_timestamp
+from shared.LoggerFactory import LoggerFactory
 
 # Root Directory (/etl)
 ROOT_DIR = os.environ['ROOT_DIR']
+logger = LoggerFactory.get_general_logger()
 
 # Contains all running scraper threads
 scraper_threads = []
@@ -19,6 +21,7 @@ def execute_scraper(scraper_file_name: str):
     Checks if the files contains a subclass of Scraper (/data_extraction/Scraper.py) and starts the run function.
     Writes the scraped data and errors during the scraping process data_extraction/data and data_extraction/errors."""
 
+    logger.info(f"execute_scraper for {scraper_file_name}")
     try:
         scraper_module = import_module(f'data_extraction.scraper.{scraper_file_name}')
         scraper_class = None
@@ -29,6 +32,7 @@ def execute_scraper(scraper_file_name: str):
                 scraper_class = scraper_sub_class
 
         if not scraper_class:
+            logger.exception(f'[{scraper_file_name}] Error: No sub-class of class Scraper found')
             raise Exception(f'[{scraper_file_name}] Error: No sub-class of class Scraper found')
 
         # Create instance of the Scraper sub-class and execute the run method 
@@ -43,11 +47,12 @@ def execute_scraper(scraper_file_name: str):
                                scraper_errors)
 
     except Exception as err:
-        print(err)
+        logger.exception(err)
 
 
 def run():
-    """Starts a thread with the execute_scraper function for all overridden scraper subclasses in /data_extraction/scraper."""
+    """Starts a thread with the execute_scraper function for all overridden scraper subclasses in
+    /data_extraction/scraper."""
 
     for file_entry in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/scraper')):
 

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -155,15 +155,10 @@ class BundesFreiwilligendienst(Scraper):
             for link_tag in detail_link_tags:
                 current_link = self.base_url + "/" + link_tag['href']
                 if current_link in self.urls:
-                    self.add_error({
-                        'func': 'add_urls',
-                        'body': {
-                            'page_index': index,
-                            'search_page': next_page_url,
-                            'duplicate_link': current_link,
-                            'duplicate_index': self.urls.index(current_link),
-                        }
-                    })
+                    self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
+                                      f" search_page: {search_page_url}, "
+                                      f"duplicate_index: {current_link}, "
+                                      f"duplicate_index: {self.urls.index(current_link)}")
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -150,6 +150,7 @@ class BundesFreiwilligendienst(Scraper):
                 index_max = next_page_tag.parent.parent.find_previous_sibling('li').a.decode_contents().strip()
 
             self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {self.base_url} [{index}/{index_max}]')
+            self.get_progress_data_fetching(index, index_max)
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:

--- a/etl/data_extraction/scraper/bundesfreiwilligendienst.py
+++ b/etl/data_extraction/scraper/bundesfreiwilligendienst.py
@@ -5,11 +5,10 @@ class BundesFreiwilligendienst(Scraper):
     """Scrapes the website bundesfreiwilligendienst.de."""
 
     base_url = "https://www.bundesfreiwilligendienst.de"
-    debug = True
 
     def parse(self, response, url):
         """Handles the soupified response of a detail page in the predefined way and returns it."""
-
+        self.logger.debug("parse()")
         content = response.find('div', {'class': 'single_view_entry clearfix'})
 
         title = content.find('h1')
@@ -125,6 +124,7 @@ class BundesFreiwilligendienst(Scraper):
 
     def add_urls(self):
         """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape."""
+        self.logger.debug("add_urls()")
 
         import time
 
@@ -149,8 +149,7 @@ class BundesFreiwilligendienst(Scraper):
             if index_max == -1 and next_page_tag is not None:
                 index_max = next_page_tag.parent.parent.find_previous_sibling('li').a.decode_contents().strip()
 
-            if self.debug:
-                print(f'Fetched {len(detail_link_tags)} URLs from {self.base_url} [{index}/{index_max}]')
+            self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {self.base_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -140,6 +140,7 @@ class EhrenamtHessenScraper(Scraper):
             detail_links = [x.find('a') for x in search_page.find_all('div', {'class': 'easSearchResultTitle'})]
 
             self.logger.debug(f'Fetched {len(detail_links)} URLs from {search_page_url} [{index}/{end_page}]')
+            self.get_progress_data_fetching(index, end_page)
 
             for detail_link in detail_links:
                 current_link = self.base_url + detail_link['href']

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -10,7 +10,7 @@ class EhrenamtHessenScraper(Scraper):
 
     def parse(self, response, url):
         """Handles the soupified response of a detail page in the predefined way and returns it."""
-        self.logger.debug("parse() for {url}")
+        self.logger.debug("parse()")
 
         tab = response.find('a', {'href': '?param&searchTab=jobentries&entryTypeId=5&showEntryTypeFilterSelect=false'})
         tab_parent_div = tab.parent
@@ -127,7 +127,7 @@ class EhrenamtHessenScraper(Scraper):
 
     def add_urls(self):
         """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape."""
-        self.logger.debug("add_urls")
+        self.logger.debug("add_urls()")
 
         end_page = self.fetch_end_page()
 
@@ -144,26 +144,17 @@ class EhrenamtHessenScraper(Scraper):
             for detail_link in detail_links:
                 current_link = self.base_url + detail_link['href']
                 if current_link in self.urls:
-                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                    self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
                                         f" search_page: {search_page_url}, "
                                         f"duplicate_index: {current_link}, "
                                         f"duplicate_index: {self.urls.index(current_link)}")
-                    #self.add_error({
-                    #    'func': 'add_urls',
-                    #    'body': {
-                    #        'page_index': index,
-                    #        'search_page': search_page_url,
-                    #        'duplicate_link': current_link,
-                    #        'duplicate_index': self.urls.index(current_link)
-                    #    }
-                    #})
                 else:
                     self.urls.append(current_link)
 
     def fetch_end_page(self):
         """Domain-specific Function.
         Fetches the number of pages from the search result page for the add_urls function."""
-        self.logger.debug("fetch_end_page")
+        self.logger.debug("fetch_end_page()")
 
         search_page_url = f'{self.base_url}/entry_search_result.cfm?locationId=0&entryTypeId=5'
         search_page = self.soupify(search_page_url)

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -2,23 +2,21 @@ import math
 import time
 
 from bs4 import BeautifulSoup
-
 from data_extraction.Scraper import Scraper
 
 
 class EhrenamtHessenScraper(Scraper):
     base_url = 'https://www.ehrenamtssuche-hessen.de'
-    debug = True
 
     def parse(self, response, url):
         """Handles the soupified response of a detail page in the predefined way and returns it."""
+        self.logger.debug("parse() for {url}")
 
         tab = response.find('a', {'href': '?param&searchTab=jobentries&entryTypeId=5&showEntryTypeFilterSelect=false'})
         tab_parent_div = tab.parent
         tab_classes = tab_parent_div['class']
         if 'active' not in tab_classes:
-            if self.debug:
-                print(f'[INFO]\t\'{url}\' is not volunteering work')
+            self.logger.debug(f"\'{url}\' is not volunteering work'")
             return None
 
         location_of = response.find('div', {'class': 'legendLeft'}, text='Ort Ihres Ehrenamts')
@@ -112,23 +110,24 @@ class EhrenamtHessenScraper(Scraper):
             organization = parsed_object['organization']
             organization = organization.replace('_self', '_blank')
             organization = organization.replace('/index.cfm', 'https://www.ehrenamtssuche-hessen.de/index.cfm')
-            organization = EhrenamtHessenScraper.__fix_mail_to_links(organization)
+            organization = self.__fix_mail_to_links(organization)
             parsed_object['organization'] = organization
 
         if parsed_object['contact'] is not None:
             contact = parsed_object['contact']
-            contact = EhrenamtHessenScraper.__fix_target_blank(contact)
+            contact = self.__fix_target_blank(contact)
             parsed_object['contact'] = contact
 
         if parsed_object['task'] is not None:
             task = parsed_object['task']
-            task = EhrenamtHessenScraper.__fix_target_blank(task)
+            task = self.__fix_target_blank(task)
             parsed_object['task'] = task
 
         return parsed_object
 
     def add_urls(self):
         """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape."""
+        self.logger.debug("add_urls")
 
         end_page = self.fetch_end_page()
 
@@ -140,26 +139,31 @@ class EhrenamtHessenScraper(Scraper):
             search_page = self.soupify(search_page_url)
             detail_links = [x.find('a') for x in search_page.find_all('div', {'class': 'easSearchResultTitle'})]
 
-            if self.debug:
-                print(f'Fetched {len(detail_links)} URLs from {search_page_url} [{index}/{end_page}]')
+            self.logger.debug(f'Fetched {len(detail_links)} URLs from {search_page_url} [{index}/{end_page}]')
+
             for detail_link in detail_links:
                 current_link = self.base_url + detail_link['href']
                 if current_link in self.urls:
-                    self.add_error({
-                        'func': 'add_urls',
-                        'body': {
-                            'page_index': index,
-                            'search_page': search_page_url,
-                            'duplicate_link': current_link,
-                            'duplicate_index': self.urls.index(current_link)
-                        }
-                    })
+                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                                        f" search_page: {search_page_url}, "
+                                        f"duplicate_index: {current_link}, "
+                                        f"duplicate_index: {self.urls.index(current_link)}")
+                    #self.add_error({
+                    #    'func': 'add_urls',
+                    #    'body': {
+                    #        'page_index': index,
+                    #        'search_page': search_page_url,
+                    #        'duplicate_link': current_link,
+                    #        'duplicate_index': self.urls.index(current_link)
+                    #    }
+                    #})
                 else:
                     self.urls.append(current_link)
 
     def fetch_end_page(self):
         """Domain-specific Function.
         Fetches the number of pages from the search result page for the add_urls function."""
+        self.logger.debug("fetch_end_page")
 
         search_page_url = f'{self.base_url}/entry_search_result.cfm?locationId=0&entryTypeId=5'
         search_page = self.soupify(search_page_url)
@@ -167,14 +171,13 @@ class EhrenamtHessenScraper(Scraper):
         formatted_entry_number = int(total_entries_as_string.replace('.', ''))
         end_page = math.ceil(formatted_entry_number / 15)
 
-        if self.debug:
-            print(f'Crawling {end_page} pages with 15 entries each.')
+        self.logger.debug(f'Crawling {end_page} pages with 15 entries each.')
 
         return end_page
 
-    @staticmethod
-    def __extract_categories(response):
+    def __extract_categories(self, response):
         """Extracts the categories from corresponding field."""
+        self.logger.debug("__extract_categories()")
 
         cat_list = []
         categories_html = response.find('div', {'class': 'legendLeft'}, text='Kategorien')
@@ -193,6 +196,7 @@ class EhrenamtHessenScraper(Scraper):
 
     def __extract_sub_data(self, value):
         """Extracts name, street, zipcode, city, phone and email from a given string."""
+        self.logger.debug("__extract_sub_data()")
 
         if value is None:
             return {
@@ -261,9 +265,10 @@ class EhrenamtHessenScraper(Scraper):
             'email': email or None,
         }
 
-    @staticmethod
-    def __fix_mail_to_links(data):
+    def __fix_mail_to_links(self, data):
         """ implements ehrenamtsuche specific fixes for mailto links in organisation field """
+        self.logger.debug("__fix_mail_to_links()")
+
         soup = BeautifulSoup(data, 'html.parser')
         links = soup.findAll('a')
         for link in links:
@@ -272,9 +277,10 @@ class EhrenamtHessenScraper(Scraper):
         data = soup.decode()
         return data
 
-    @staticmethod
-    def __fix_target_blank(data):
+    def __fix_target_blank(self, data):
         """ implements ehrenamtsuche specific fixes for mailto links in task and contact field """
+        self.logger.debug("__fix_target_blank()")
+
         soup = BeautifulSoup(data, 'html.parser')
         links = soup.findAll('a')
         for link in links:

--- a/etl/data_extraction/scraper/ehrenamt_hessen.py
+++ b/etl/data_extraction/scraper/ehrenamt_hessen.py
@@ -145,9 +145,9 @@ class EhrenamtHessenScraper(Scraper):
                 current_link = self.base_url + detail_link['href']
                 if current_link in self.urls:
                     self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
-                                        f" search_page: {search_page_url}, "
-                                        f"duplicate_index: {current_link}, "
-                                        f"duplicate_index: {self.urls.index(current_link)}")
+                                      f" search_page: {search_page_url}, "
+                                      f"duplicate_index: {current_link}, "
+                                      f"duplicate_index: {self.urls.index(current_link)}")
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -1,4 +1,5 @@
 from data_extraction.Scraper import Scraper
+from shared.ProgressBar import ProgressBar
 
 import re
 import math
@@ -122,6 +123,7 @@ class EinJahrFreiwillig(Scraper):
             index_max = math.ceil(index_max / 20)
 
             self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.get_progress_data_fetching(index, index_max)
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -121,22 +121,25 @@ class EinJahrFreiwillig(Scraper):
             index_max = float(re.search('([0-9]+) Treffer', response.find('div', {'class': 'field-result-count'}).decode_contents().strip()).group(1))
             index_max = math.ceil(index_max / 20)
 
-            if self.debug:
-                print(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.logger.info(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:
                 current_link = self.base_url + link_tag['href']
                 if current_link in self.urls:
-                    self.add_error({
-                        'func': 'add_urls',
-                        'body': {
-                            'page_index': index,
-                            'search_page': next_page_url,
-                            'duplicate_link': current_link,
-                            'duplicate_index': self.urls.index(current_link),
-                        }
-                    })
+                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                                        f" search_page: {search_page_url}, "
+                                        f"duplicate_index: {current_link}, "
+                                        f"duplicate_index: {self.urls.index(current_link)}")
+                    #self.add_error({
+                    #    'func': 'add_urls',
+                    #    'body': {
+                    #        'page_index': index,
+                    #        'search_page': next_page_url,
+                    #        'duplicate_link': current_link,
+                    #        'duplicate_index': self.urls.index(current_link),
+                    #    }
+                    #})
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -128,9 +128,9 @@ class EinJahrFreiwillig(Scraper):
                 current_link = self.base_url + link_tag['href']
                 if current_link in self.urls:
                     self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
-                                        f" search_page: {search_page_url}, "
-                                        f"duplicate_index: {current_link}, "
-                                        f"duplicate_index: {self.urls.index(current_link)}")
+                                      f" search_page: {search_page_url}, "
+                                      f"duplicate_index: {current_link}, "
+                                      f"duplicate_index: {self.urls.index(current_link)}")
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/ein_jahr_freiwillig.py
+++ b/etl/data_extraction/scraper/ein_jahr_freiwillig.py
@@ -103,7 +103,7 @@ class EinJahrFreiwillig(Scraper):
 
     def add_urls(self):
         """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape"""
-
+        self.logger.debug("add_urls()")
         import time
 
         search_page_url = f'{self.base_url}/de/suche/ort?geo%5Bvalue%5D=10&geo%5Bsource_configuration%5D%5Borigin_address%5D=&last_minute=All&unterkunft=All&anbieter=&page=0'
@@ -121,25 +121,16 @@ class EinJahrFreiwillig(Scraper):
             index_max = float(re.search('([0-9]+) Treffer', response.find('div', {'class': 'field-result-count'}).decode_contents().strip()).group(1))
             index_max = math.ceil(index_max / 20)
 
-            self.logger.info(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:
                 current_link = self.base_url + link_tag['href']
                 if current_link in self.urls:
-                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                    self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
                                         f" search_page: {search_page_url}, "
                                         f"duplicate_index: {current_link}, "
                                         f"duplicate_index: {self.urls.index(current_link)}")
-                    #self.add_error({
-                    #    'func': 'add_urls',
-                    #    'body': {
-                    #        'page_index': index,
-                    #        'search_page': next_page_url,
-                    #        'duplicate_link': current_link,
-                    #        'duplicate_index': self.urls.index(current_link),
-                    #    }
-                    #})
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/gutetat_berlin.py
+++ b/etl/data_extraction/scraper/gutetat_berlin.py
@@ -20,7 +20,6 @@ class GuteTatBerlinScraper(Scraper):
 
     def parse(self, response, url):
         """Transforms the soupified response of a detail page in a predefined way and returns it."""
-
         self.logger.debug("parse()")
 
         main_table = response.find('table')
@@ -104,7 +103,6 @@ class GuteTatBerlinScraper(Scraper):
 
     def add_urls(self):
         """Adds URLs to an array which is later iterated over and scraped each."""
-
         self.logger.debug("add_urls()")
 
         end_page = self.__fetch_end_page()
@@ -122,27 +120,15 @@ class GuteTatBerlinScraper(Scraper):
             for detail_link in detail_links:
                 current_link = self.base_url + detail_link['href']
                 if current_link in self.urls:
-                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                    self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
                                         f" search_page: {search_page_url}, "
                                         f"duplicate_index: {current_link}, "
                                         f"duplicate_index: {self.urls.index(current_link)}")
-                    #self.add_error({
-                    #    'func': 'add_urls',
-                    #    'body': {
-                    #        'page_index': index,
-                    #        'search_page': search_page_url,
-                    #        'duplicate_link': current_link,
-                    #        'duplicate_index': self.urls.index(current_link)
-                    #    }
-                    #})
                 else:
                     self.urls.append(current_link)
 
-        self.logger.debug(len(self.urls))
-
     def __fetch_end_page(self):
         """Fetches the number of pages from the search result page for the add_urls function."""
-
         self.logger.debug("__fetch_end_page()")
 
         entries_per_page = 30

--- a/etl/data_extraction/scraper/gutetat_berlin.py
+++ b/etl/data_extraction/scraper/gutetat_berlin.py
@@ -121,9 +121,9 @@ class GuteTatBerlinScraper(Scraper):
                 current_link = self.base_url + detail_link['href']
                 if current_link in self.urls:
                     self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
-                                        f" search_page: {search_page_url}, "
-                                        f"duplicate_index: {current_link}, "
-                                        f"duplicate_index: {self.urls.index(current_link)}")
+                                      f" search_page: {search_page_url}, "
+                                      f"duplicate_index: {current_link}, "
+                                      f"duplicate_index: {self.urls.index(current_link)}")
                 else:
                     self.urls.append(current_link)
 

--- a/etl/data_extraction/scraper/gutetat_berlin.py
+++ b/etl/data_extraction/scraper/gutetat_berlin.py
@@ -116,6 +116,7 @@ class GuteTatBerlinScraper(Scraper):
             detail_links = [x for x in search_page.find_all('a', {'class': 'links'})][:-1]
 
             self.logger.debug(f'Fetched {len(detail_links)} URLs from {search_page_url} [{index}/{end_page}]')
+            self.get_progress_data_fetching(index, end_page)
 
             for detail_link in detail_links:
                 current_link = self.base_url + detail_link['href']

--- a/etl/data_extraction/scraper/weltwaerts.py
+++ b/etl/data_extraction/scraper/weltwaerts.py
@@ -114,6 +114,7 @@ class WeltwaertsScraper(Scraper):
             index_max = index_max.split(" von ", 1)[1]
 
             self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.get_progress_data_fetching(index, index_max)
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:

--- a/etl/data_extraction/scraper/weltwaerts.py
+++ b/etl/data_extraction/scraper/weltwaerts.py
@@ -111,22 +111,25 @@ class WeltwaertsScraper(Scraper):
             index_max = response.find('div', {'class': 'result__pagination'}).nav.p.decode_contents().strip()
             index_max = index_max.split(" von ", 1)[1]
 
-            if self.debug:
-                print(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.logger.info(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:
                 current_link = self.base_url + '/' + link_tag['href']
                 if current_link in self.urls:
-                    self.add_error({
-                        'func': 'add_urls',
-                        'body': {
-                            'page_index': index,
-                            'search_page': next_page_url,
-                            'duplicate_link': current_link,
-                            'duplicate_index': self.urls.index(current_link)
-                        }
-                    })
+                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                                        f" search_page: {search_page_url}, "
+                                        f"duplicate_index: {current_link}, "
+                                        f"duplicate_index: {self.urls.index(current_link)}")
+                    #self.add_error({
+                    #    'func': 'add_urls',
+                    #    'body': {
+                    #        'page_index': index,
+                    #        'search_page': next_page_url,
+                    #        'duplicate_link': current_link,
+                    #        'duplicate_index': self.urls.index(current_link)
+                    #    }
+                    #})
                 else:
                     self.urls.append(current_link)
 
@@ -153,7 +156,7 @@ class WeltwaertsScraper(Scraper):
 
         # Removing HTML-Tags
         contact_raw = re.sub(r'<br/?>', '\n', contact_raw)
-        contact_raw = Scraper.clean_html_tags(contact_raw)
+        contact_raw = self.clean_html_tags(contact_raw)
 
         contact_split = list(filter(lambda s: 'E-mail' not in s, filter(None, re.split('\n|,', contact_raw))))
 

--- a/etl/data_extraction/scraper/weltwaerts.py
+++ b/etl/data_extraction/scraper/weltwaerts.py
@@ -120,9 +120,9 @@ class WeltwaertsScraper(Scraper):
                 current_link = self.base_url + '/' + link_tag['href']
                 if current_link in self.urls:
                     self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
-                                        f" search_page: {search_page_url}, "
-                                        f"duplicate_index: {current_link}, "
-                                        f"duplicate_index: {self.urls.index(current_link)}")
+                                      f" search_page: {search_page_url}, "
+                                      f"duplicate_index: {current_link}, "
+                                      f"duplicate_index: {self.urls.index(current_link)}")
 
                 else:
                     self.urls.append(current_link)

--- a/etl/data_extraction/scraper/weltwaerts.py
+++ b/etl/data_extraction/scraper/weltwaerts.py
@@ -11,6 +11,7 @@ class WeltwaertsScraper(Scraper):
 
     def parse(self, response, url):
         """Handles the soupified response of a detail page in the predefined way and returns it"""
+        self.logger.debug("parse()")
 
         param_box = response.find('div', {'class': 'parameter__box'})
 
@@ -89,6 +90,7 @@ class WeltwaertsScraper(Scraper):
 
     def add_urls(self):
         """Adds all URLs of detail pages, found on the search pages, for the crawl function to scrape"""
+        self.logger.debug("add_urls()")
 
         import time
 
@@ -111,25 +113,17 @@ class WeltwaertsScraper(Scraper):
             index_max = response.find('div', {'class': 'result__pagination'}).nav.p.decode_contents().strip()
             index_max = index_max.split(" von ", 1)[1]
 
-            self.logger.info(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
+            self.logger.debug(f'Fetched {len(detail_link_tags)} URLs from {next_page_url} [{index}/{index_max}]')
 
             # Iterate links and add, if not already found
             for link_tag in detail_link_tags:
                 current_link = self.base_url + '/' + link_tag['href']
                 if current_link in self.urls:
-                    self.logger.warning(f"func: add_urls, 'body:'page_index: {index},"
+                    self.logger.debug(f"func: add_urls, 'body:'page_index: {index},"
                                         f" search_page: {search_page_url}, "
                                         f"duplicate_index: {current_link}, "
                                         f"duplicate_index: {self.urls.index(current_link)}")
-                    #self.add_error({
-                    #    'func': 'add_urls',
-                    #    'body': {
-                    #        'page_index': index,
-                    #        'search_page': next_page_url,
-                    #        'duplicate_link': current_link,
-                    #        'duplicate_index': self.urls.index(current_link)
-                    #    }
-                    #})
+
                 else:
                     self.urls.append(current_link)
 
@@ -144,6 +138,7 @@ class WeltwaertsScraper(Scraper):
 
     def __extract_contact_data(self, contact_html, contact_raw):
         """Extracts the contact data"""
+        self.logger.debug("__extract_contact_data()")
 
         contact = {
             'name': None,

--- a/etl/execute_elastic_upload.py
+++ b/etl/execute_elastic_upload.py
@@ -4,5 +4,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 os.environ['ROOT_DIR'] = ROOT_DIR
 
 from upload_to_elasticsearch.elastic import run_elastic_upload
+from shared.LoggerFactory import LoggerFactory
 
+LoggerFactory.get_elastic_logger().debug("running elastic upload")
 run_elastic_upload()

--- a/etl/execute_elastic_upload.py
+++ b/etl/execute_elastic_upload.py
@@ -6,5 +6,5 @@ os.environ['ROOT_DIR'] = ROOT_DIR
 from upload_to_elasticsearch.elastic import run_elastic_upload
 from shared.LoggerFactory import LoggerFactory
 
-LoggerFactory.get_elastic_logger().debug("running elastic upload")
+LoggerFactory.get_elastic_logger().info("running elastic upload")
 run_elastic_upload()

--- a/etl/main.py
+++ b/etl/main.py
@@ -11,13 +11,15 @@ sys.path.extend([f'{ROOT_DIR}/data_extraction', f'{ROOT_DIR}/shared'])
 from data_enhancement import enhance_data as enhance_data
 from data_extraction.scrape_data import run as run_extraction
 from shared.utils import write_data_to_json, read_data_from_json
+from shared.LoggerFactory import LoggerFactory
 
+
+logger = LoggerFactory.get_general_logger()
 # Runs the extraction process and writes the scraped data to data_extraction/data directory
 run_extraction()
 
 for file in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/data')):
     file_name = os.path.splitext(file.name)[0]
-
     # read scraped data for enhancement
     data = read_data_from_json(file.path)
 

--- a/etl/shared/LoggerFactory.py
+++ b/etl/shared/LoggerFactory.py
@@ -22,15 +22,15 @@ class LoggerFactory:
         """Returns logger with the set name if it exists, otherwise sets up logger with the requested name.
         default: only WARNING messages or above get displayed, DEBUG-level and above is written to logfile"""
 
-        if name in LoggerFactory.logger_dict:
-            return LoggerFactory.logger_dict[name]
-
         if not os.path.exists(os.path.join(ROOT_DIR, 'logs')):
             os.makedirs(os.path.join(ROOT_DIR, 'logs'))
 
-        # set up general formatting for log messages
+        if name in LoggerFactory.logger_dict:
+            return LoggerFactory.logger_dict[name]
+
+        # set up general formatting for displayed log messages
         formatter_display = logging.Formatter('%(asctime)s [%(levelname)s]:\t %(message)s', "%Y-%m-%d %H:%M:%S")
-        # prettier print and module information for logfile
+        # prettier 2 line print and module information for logfile
         formatter_logfile = logging.Formatter('%(asctime)s [%(levelname)s]\n\t\t\t\t\t[%(module)s]:\t %(message)s',
                                               "%Y-%m-%d %H:%M:%S")
 
@@ -67,5 +67,5 @@ class LoggerFactory:
 
     @staticmethod
     def get_elastic_logger():
-        """Returns general logger for enhancement modules"""
+        """Returns general logger for elastic"""
         return LoggerFactory.get_logger('elastic')

--- a/etl/shared/LoggerFactory.py
+++ b/etl/shared/LoggerFactory.py
@@ -5,7 +5,7 @@ ROOT_DIR = os.environ['ROOT_DIR']
 
 
 class LoggerFactory:
-
+    """ This class handles the different loggers according to a singleton factory pattern """
     logger_dict = dict()
     # Set levels for display / writing to logfile. Levels are in ascending order:
     # NOTSET

--- a/etl/shared/LoggerFactory.py
+++ b/etl/shared/LoggerFactory.py
@@ -1,0 +1,66 @@
+import logging
+import os
+
+ROOT_DIR = os.environ['ROOT_DIR']
+
+
+class LoggerFactory:
+
+    logger_dict = dict()
+    # Set levels for display / writing to logfile. Levels are in ascending order:
+    # NOTSET
+    # DEBUG
+    # INFO
+    # WARNING
+    # ERROR
+    # CRITICAL
+    display_level = logging.INFO
+    logfile_level = logging.DEBUG
+
+    @staticmethod
+    def get_logger(name):
+        """Returns logger with the set name if it exists, otherwise sets up logger with the requested name.
+        default: only WARNING messages or above get displayed, DEBUG-level and above is written to logfile"""
+
+        if name in LoggerFactory.logger_dict:
+            return LoggerFactory.logger_dict[name]
+
+        if not os.path.exists(os.path.join(ROOT_DIR, 'logs')):
+            os.makedirs(os.path.join(ROOT_DIR, 'logs'))
+
+        # set up general formatting for log messages
+        formatter_display = logging.Formatter('%(asctime)s [%(levelname)s]:\t %(message)s', "%Y-%m-%d %H:%M:%S")
+        # prettier print and module information for logfile
+        formatter_logfile = logging.Formatter('%(asctime)s [%(levelname)s]\n\t\t\t\t\t[%(module)s]:\t %(message)s',
+                                              "%Y-%m-%d %H:%M:%S")
+
+        # set up logging to logfile. all levels of messages will be logged to individual files, old contents will be
+        # overwritten
+        file_handler = logging.FileHandler(os.path.join(ROOT_DIR, 'logs', f'{name}.log'), 'w+')
+        file_handler.setFormatter(formatter_logfile)
+        file_handler.setLevel(LoggerFactory.logfile_level)
+
+        # set up display of logging messages. only messages of that are at the level of message_level or above will be
+        # logged
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter_display)
+        stream_handler.setLevel(LoggerFactory.display_level)
+
+        # set up logger and register handlers
+        new_logger = logging.getLogger(name)
+        # general logging level set to INFO so all messages can be passed on to the handlers
+        new_logger.setLevel(logging.DEBUG)
+        new_logger.addHandler(file_handler)
+        new_logger.addHandler(stream_handler)
+        LoggerFactory.logger_dict[name] = new_logger
+        return new_logger
+
+    @staticmethod
+    def get_general_logger():
+        """Returns general logger for overall logging across different modules"""
+        return LoggerFactory.get_logger('general_etl')
+
+    @staticmethod
+    def get_enhancement_logger():
+        """Returns general logger for enhancement modules"""
+        return LoggerFactory.get_logger('enhancement')

--- a/etl/shared/LoggerFactory.py
+++ b/etl/shared/LoggerFactory.py
@@ -64,3 +64,8 @@ class LoggerFactory:
     def get_enhancement_logger():
         """Returns general logger for enhancement modules"""
         return LoggerFactory.get_logger('enhancement')
+
+    @staticmethod
+    def get_elastic_logger():
+        """Returns general logger for enhancement modules"""
+        return LoggerFactory.get_logger('elastic')

--- a/etl/shared/ProgressBar.py
+++ b/etl/shared/ProgressBar.py
@@ -6,51 +6,85 @@ class ProgressBar:
     lock = Lock()
     progress_data = dict()
     logger = LoggerFactory.get_general_logger()
+    MODE_FETCHING = "fetching pages"
+    MODE_CRAWLING = "crawling"
+    MODE_INITIALISING = "initialising"
+    PADLENGTH = 25
 
     @staticmethod
-    def __add_progress_data(key, current, total):
+    def __add_progress_data(key, current, total, mode):
+        """registers progress data for crawler"""
+
         ProgressBar.logger.debug("__add_progress_data()")
 
         ProgressBar.lock.acquire()
         try:
-            ProgressBar.progress_data[key] = [current, total]
+            ProgressBar.progress_data[key] = [current, total, mode]
 
         finally:
             ProgressBar.lock.release()
 
     @staticmethod
     def register_crawler(name):
+        """ registers crawler without progress data """
         ProgressBar.logger.debug("register_crawler()")
+
         ProgressBar.lock.acquire()
         try:
-            ProgressBar.progress_data[name] = [0, 0]
+            ProgressBar.progress_data[name] = ["0", "0", ProgressBar.MODE_INITIALISING]
 
         finally:
             ProgressBar.lock.release()
 
     @staticmethod
-    def __generate_progress_bar(name, current, total):
+    def add_time(name, time):
+        """ adds finish time of a crawler to progress data"""
+        ProgressBar.logger.debug("add_time()")
+
+        ProgressBar.lock.acquire()
+        try:
+            ProgressBar.progress_data[name].append(time)
+
+        finally:
+            ProgressBar.lock.release()
+
+    @staticmethod
+    def __generate_progress_bar(name, current, total, max_len):
+        """ generates a progress bar for a single crawler and returns it as a string"""
         ProgressBar.logger.debug("__generate_progress_bar()")
-        description = ""
-        if total == 0:
+
+        description = f"{''.ljust(ProgressBar.PADLENGTH)} [{ProgressBar.progress_data[name][2]}]"
+        if int(total) == 0:
             percentage = 0
-            description = "(still fetching pages)"
         else:
-            percentage = int(100 * current / total)
+            percentage = int(100 * int(current) / int(total))
             if percentage == 100:
-                description = "(finished)"
+                if len(ProgressBar.progress_data[name]) == 4:
+                    description = f"{ProgressBar.__pad_to_length(percentage,current,total)} [finished after " \
+                                  f"{ProgressBar.progress_data[name][3]} seconds]"
+                else:
+                    description = f"{ProgressBar.__pad_to_length(percentage,current,total)}" \
+                                  f" [{ProgressBar.progress_data[name][2]}]"
             else:
-                description = f"{percentage}% ({current}/{total})"
+                description = f"{ProgressBar.__pad_to_length(percentage,current,total)}" \
+                              f" [{ProgressBar.progress_data[name][2]}]"
         bar = ''.join(['#' * int(percentage / 2)])
         size_bar_missing = 50 - len(bar)
         bar_missing = ''.join(["-" * size_bar_missing])
         bar = bar + bar_missing
-        return f"{name}\t [{bar}] {description}"
+        return f"{name.ljust(max_len)}\t [{bar}] {description}"
 
     @staticmethod
-    def get_progress_data(name, current, total):
+    def __pad_to_length(percentage, current, total):
+        """ builds padded string for proper mode description alignment"""
+        return f"{percentage}% ({current}/{total})".ljust(ProgressBar.PADLENGTH)
+
+    @staticmethod
+    def get_progress_data(name, current, total, mode):
+        """ updates progress data for crawler and prints complete progress bar"""
+
         ProgressBar.logger.debug("get_progress_data()")
-        ProgressBar.__add_progress_data(name, current, total)
+        ProgressBar.__add_progress_data(name, current, total, mode)
         ProgressBar.lock.acquire()
         try:
             progress_data = ProgressBar.progress_data.copy()
@@ -65,9 +99,10 @@ class ProgressBar:
 
         for key in progress_data:
             bars.append(ProgressBar.__generate_progress_bar(
-                key.ljust(max_len),
+                key,
                 progress_data[key][0],
-                progress_data[key][1]
+                progress_data[key][1],
+                max_len
             ))
 
         progress_bar = bars[0]

--- a/etl/shared/ProgressBar.py
+++ b/etl/shared/ProgressBar.py
@@ -3,11 +3,12 @@ from shared.LoggerFactory import LoggerFactory
 
 
 class ProgressBar:
+    """ This class stores the progress data of all crawlers and displays it"""
     lock = Lock()
     progress_data = dict()
     logger = LoggerFactory.get_general_logger()
     MODE_FETCHING = "fetching pages"
-    MODE_CRAWLING = "crawling"
+    MODE_CRAWLING = "crawling pages"
     MODE_INITIALISING = "initialising"
     PADLENGTH = 25
 

--- a/etl/shared/ProgressBar.py
+++ b/etl/shared/ProgressBar.py
@@ -1,0 +1,70 @@
+from threading import Lock
+from shared.LoggerFactory import LoggerFactory
+
+
+class ProgressBar:
+    lock = Lock()
+    progress_data = dict()
+    logger = LoggerFactory.get_general_logger()
+
+    @staticmethod
+    def __add_progress_data(key, current, total):
+        ProgressBar.logger.debug("__add_progress_data()")
+
+        ProgressBar.lock.acquire()
+        try:
+            ProgressBar.progress_data[key] = [current, total]
+
+        finally:
+            ProgressBar.lock.release()
+
+    @staticmethod
+    def register_crawler(name):
+        ProgressBar.logger.debug("register_crawler()")
+        ProgressBar.lock.acquire()
+        try:
+            ProgressBar.progress_data[name] = [0, 0]
+
+        finally:
+            ProgressBar.lock.release()
+
+    @staticmethod
+    def __generate_progress_bar(name, current, total):
+        ProgressBar.logger.debug("__generate_progress_bar()")
+        if total == 0:
+            percentage = 0
+        else:
+            percentage = int(100 * current / total)
+        bar = ''.join(['X' * int(percentage / 2)])
+        size_bar_missing = 50 - len(bar)
+        bar_missing = ''.join(["-" * size_bar_missing])
+        bar = bar + bar_missing
+        return f"{name}\t [{bar}] {percentage}% ({current}/{total})"
+
+    @staticmethod
+    def get_progress_data(name, current, total):
+        ProgressBar.logger.debug("get_progress_data()")
+        ProgressBar.__add_progress_data(name, current, total)
+        ProgressBar.lock.acquire()
+        try:
+            progress_data = ProgressBar.progress_data.copy()
+        finally:
+            ProgressBar.lock.release()
+        max_len = 0
+        for key in progress_data:
+            if len(key) > max_len:
+                max_len = len(key)
+
+        bars = []
+
+        for key in progress_data:
+            bars.append(ProgressBar.__generate_progress_bar(
+                key.ljust(max_len),
+                progress_data[key][0],
+                progress_data[key][1]
+            ))
+
+        progress_bar = bars[0]
+        for index in range(1, len(bars)):
+            progress_bar = progress_bar + "\n" + bars[index]
+        return progress_bar

--- a/etl/shared/ProgressBar.py
+++ b/etl/shared/ProgressBar.py
@@ -31,15 +31,21 @@ class ProgressBar:
     @staticmethod
     def __generate_progress_bar(name, current, total):
         ProgressBar.logger.debug("__generate_progress_bar()")
+        description = ""
         if total == 0:
             percentage = 0
+            description = "(still fetching pages)"
         else:
             percentage = int(100 * current / total)
-        bar = ''.join(['X' * int(percentage / 2)])
+            if percentage == 100:
+                description = "(finished)"
+            else:
+                description = f"{percentage}% ({current}/{total})"
+        bar = ''.join(['#' * int(percentage / 2)])
         size_bar_missing = 50 - len(bar)
         bar_missing = ''.join(["-" * size_bar_missing])
         bar = bar + bar_missing
-        return f"{name}\t [{bar}] {percentage}% ({current}/{total})"
+        return f"{name}\t [{bar}] {description}"
 
     @staticmethod
     def get_progress_data(name, current, total):

--- a/etl/shared/ProgressBar.py
+++ b/etl/shared/ProgressBar.py
@@ -73,4 +73,4 @@ class ProgressBar:
         progress_bar = bars[0]
         for index in range(1, len(bars)):
             progress_bar = progress_bar + "\n" + bars[index]
-        return progress_bar
+        print("\n"+progress_bar)

--- a/etl/shared/utils.py
+++ b/etl/shared/utils.py
@@ -1,10 +1,13 @@
 from datetime import datetime
+from shared.LoggerFactory import LoggerFactory
 import json
 import os
 
+logger = LoggerFactory.get_general_logger()
 
 def write_data_to_json(path, data):
     """Writes the given data to the given json file."""
+    logger.debug("write_data_to_json()")
 
     dir_name = os.path.dirname(path)
     if not os.path.exists(dir_name):
@@ -16,6 +19,7 @@ def write_data_to_json(path, data):
 
 def read_data_from_json(path):
     """Reads the given json file."""
+    logger.debug("read_data_from_json()")
 
     if not os.path.exists(path):
         print(f'Enhanced data file does not exist! [{path}]')
@@ -26,6 +30,7 @@ def read_data_from_json(path):
 
 def append_data_to_json(path, data):
     """Appends json data to the given json file."""
+    logger.debug("append_data_to_json()")
 
     if data is not None:
         json_load = read_data_from_json(path)
@@ -35,6 +40,7 @@ def append_data_to_json(path, data):
 
 def get_current_timestamp():
     """Get's the current timestamp in a specific format."""
+    logger.debug("get_current_timestamp()")
 
     now = datetime.now()
 

--- a/etl/upload_to_elasticsearch/elastic.py
+++ b/etl/upload_to_elasticsearch/elastic.py
@@ -5,13 +5,16 @@ import os
 from elasticsearch import Elasticsearch
 
 from shared.utils import read_data_from_json
+from shared.LoggerFactory import LoggerFactory
 
 ROOT_DIR = os.environ['ROOT_DIR']
 client = Elasticsearch([{'host': '127.0.0.1', 'port': 9200}])
-
+logger = LoggerFactory.get_elastic_logger()
 
 def run_elastic_upload():
-    print('[INFO]\tStarting Index Process!')
+    logger.debug("run_elastic_upload")
+    logger.info("Starting Index Process!")
+
     index = 'posts'
     if client.indices.exists(index=index):
         client.indices.delete(index=index, ignore=[400, 404])
@@ -24,19 +27,21 @@ def run_elastic_upload():
     }
 
     client.indices.create(index=index, body=request_body)
-    print('[INFO]\tFinished Indexing!')
+    logger.info("Finished Indexing!")
 
     for file in os.scandir(os.path.join(ROOT_DIR, 'data_enhancement/data')):
-        print(f'[INFO]\t{file.name}: Starting data upload')
+        logger.info(f'{file.name}: Starting data upload')
         # read enhanced data for indexing
         data = read_data_from_json(file.path)
 
         # Write enhanced data to Elastic Search
         write_to_elastic(data, index)
-        print(f'[INFO]\t{file.name}: Finished data upload')
+        logger.info(f'{file.name}: Finished data upload')
 
 
 def write_to_elastic(posts, index):
+    logger.debug("write_to_elastic()")
+
     ids = []
     for post in posts:
         if post is not None:


### PR DESCRIPTION
Added logging to all modules. Verbose logging is written to etl/logs, console output contains output about progress of all crawlers. You can control what level of log messages should be displayed / written to file via the display_level and logfile_level in LoggerFactory.py line 17-18

There are individual logfiles for the general process of starting crawlers (general), the individual crawlers(logfiles named after crawler names), the enhancement process(enhancement) and elastic upload(elastic). Log files are overwritten at the start of each session.

Logging does not add to runtime, crawlers for ehrenamt_hessen, gutetat_berlin, gutetat_hamburg, gutetat_munich and weltwaerts did not take longer than previously when running parallel. runtime for the crawlers bundesfreiwilligendienst and ein_jahr_freiwillig was not tested as their runtime far exceeds the other crawlers, but it is to be expected that their runtime is also unaffected by the addition of logging.

closes #209 