### PR TITLE
261/move upload to elastic search to the beginning of the crawling process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ etl/logs
 etl/test/**/logs
 /etl/data_management/upload/
 /etl/data_management/backups/
+/etl/data_management/upload_origin.txt

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ etl/logs
 etl/test/**/logs
 /etl/data_management/upload/
 /etl/data_management/backups/
-/etl/data_management/upload_origin.txt

--- a/etl/data_management/DataManager.py
+++ b/etl/data_management/DataManager.py
@@ -38,7 +38,7 @@ class DataManager:
     enhanced_data_location = os.path.join(ROOT_DIR, 'data_enhancement/data')
     backup_directory = os.path.join(ROOT_DIR, 'data_management', 'backups')
     upload_directory = os.path.join(ROOT_DIR, 'data_management', 'upload')
-    file_upload_data_origin = os.path.join(ROOT_DIR, 'data_management','upload_origin.txt')
+    file_upload_data_origin = os.path.join(ROOT_DIR, 'data_management', 'upload_data_origin.log')
 
     mask_timestamp = '%d.%m.%Y'
 

--- a/etl/data_management/DataManager.py
+++ b/etl/data_management/DataManager.py
@@ -38,7 +38,7 @@ class DataManager:
     enhanced_data_location = os.path.join(ROOT_DIR, 'data_enhancement/data')
     backup_directory = os.path.join(ROOT_DIR, 'data_management', 'backups')
     upload_directory = os.path.join(ROOT_DIR, 'data_management', 'upload')
-    file_upload_data_origin = os.path.join(ROOT_DIR, 'data_management', 'upload_data_origin.log')
+    file_upload_data_origin = os.path.join(ROOT_DIR, 'logs', 'upload_data_origin.log')
 
     mask_timestamp = '%d.%m.%Y'
 

--- a/etl/data_management/DataManager.py
+++ b/etl/data_management/DataManager.py
@@ -38,6 +38,7 @@ class DataManager:
     enhanced_data_location = os.path.join(ROOT_DIR, 'data_enhancement/data')
     backup_directory = os.path.join(ROOT_DIR, 'data_management', 'backups')
     upload_directory = os.path.join(ROOT_DIR, 'data_management', 'upload')
+    file_upload_data_origin = os.path.join(ROOT_DIR, 'data_management','upload_origin.txt')
 
     mask_timestamp = '%d.%m.%Y'
 
@@ -58,6 +59,15 @@ class DataManager:
         DataManager.logger.debug("datestring_to_timestamp()")
 
         return time.mktime(datetime.datetime.strptime(datestring, DataManager.mask_timestamp).timetuple())
+
+    @staticmethod
+    def save_upload_data_origin(upload_data_origin):
+        """Saves the information about the origin of the data inside the upload folder into a text file"""
+        file = open(DataManager.file_upload_data_origin, 'w')
+        file.write(f"last upload: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        file.write(f"Source for upload data:")
+        file.write(upload_data_origin)
+        file.close()
 
     @staticmethod
     def copy_from_backup(backup):
@@ -182,8 +192,9 @@ class DataManager:
                                                 f"data")
                         write_data_to_json(os.path.join(DataManager.upload_directory, upload_file), data_in_backup)
                         DataManager.data_origin[upload_file] = backup
-
-        DataManager.logger.info(f"Source for upload data: {DataManager.build_string_data_origin()}")
+        upload_data_origin = DataManager.build_string_data_origin()
+        DataManager.save_upload_data_origin(upload_data_origin)
+        DataManager.logger.info(f"Source for upload data: {upload_data_origin}")
 
     @staticmethod
     def init():
@@ -204,11 +215,18 @@ class DataManager:
             DataManager.fallback_depth = DataManager.max_number_of_backups
 
     @staticmethod
-    def run():
-        """Runs the datamangement process"""
-        DataManager.logger.debug("run()")
+    def run_backup_process():
+        """Runs the datamangement process for creating backups"""
+        DataManager.logger.debug("run_backup_process()")
 
         DataManager.init()
         DataManager.backup_current_data()
         DataManager.remove_old_backups()
+
+    @staticmethod
+    def run_compose_upload_process():
+        """Runs the datamangement process for composing the upload"""
+        DataManager.logger.debug("run_compose_upload_process()")
+
+        DataManager.init()
         DataManager.compose_upload()

--- a/etl/execute_elastic_upload.py
+++ b/etl/execute_elastic_upload.py
@@ -5,6 +5,8 @@ os.environ['ROOT_DIR'] = ROOT_DIR
 
 from upload_to_elasticsearch.elastic import run_elastic_upload
 from shared.LoggerFactory import LoggerFactory
+from data_management.DataManager import DataManager
 
 LoggerFactory.get_elastic_logger().info("running elastic upload")
+DataManager.run_compose_upload_process()
 run_elastic_upload()

--- a/etl/main.py
+++ b/etl/main.py
@@ -30,4 +30,4 @@ for file in os.scandir(os.path.join(ROOT_DIR, 'data_extraction/data')):
     # Write enhanced data to files
     write_data_to_json(os.path.join(ROOT_DIR, 'data_enhancement/data', f'{file_name}.json'), enhanced_data)
 
-DataManager.run()
+DataManager.run_backup_process()

--- a/etl/scripts/run_etl.sh
+++ b/etl/scripts/run_etl.sh
@@ -5,11 +5,11 @@ cd /home/etl/einander-helfen/etl/scripts
 # Installing required python packages
 pip3 install -r ../requirements.txt
 
-# executing crawl and enhancement
-python3 ../main.py
-
 # execute elastic upload
 python3 ../execute_elastic_upload.py
+
+# executing crawl and enhancement
+python3 ../main.py
 
 # package enhanced data for prod
 tar cfvz enhanced_output.tar.gz ../data_enhancement/data ../data_enhancement/output


### PR DESCRIPTION
closes #261 

To test this:
* go to `etl\data_management\upload` and delete all files if present.
* comment out line 20-32 in `main.py` to only run the backup process without crawling and enhancement
* run `main.py`
  * check that `etl\data_management\upload` is still empty
* comment out line 12 in `execute_elastic_upload.py` to only run the upload compose process without the elastic search upload
* run `execute_elastic_upload.py`
  * check that `etl\data_management\upload` is no longer empty
  * check that `etl\data_management\upload_data_origin.log` exists and contains the information of the upload component
This verifies that the upload composition process has been successfully split from the backup process