### PR TITLE
290/revise address parsing for unstructured address fields 

### DIFF
--- a/etl/data_enhancement/enhancement_location/lat_lon_enhancer.py
+++ b/etl/data_enhancement/enhancement_location/lat_lon_enhancer.py
@@ -62,6 +62,7 @@ class LatLonEnhancer:
                     post['geo_location'] = lat_lon
                     post['post_struct']['geo_location'] = lat_lon
                     LatLonEnhancer.logger.debug(f"Used cache to enhance lat lon for {post}")
+                    break
 
     def __check_local_storage(self, request_string):
         """Checks if local storage contains a result for the query. If it does, the geo_location object is returned.


### PR DESCRIPTION
In order to add more accurate coordinates to the posts, a further function has been added to the enhancement process to use the unstructured location data first before referencing the land.
In addition, unsuccessful geocoder requests are stored in a blacklist to speed up future requests.

close #290