### PR TITLE
Use v-app-bar-nav-icon

### DIFF
--- a/app/src/components/layout/Toolbar.vue
+++ b/app/src/components/layout/Toolbar.vue
@@ -4,9 +4,9 @@
                     <v-row>
                         <v-col class="column logoCol">
                             <v-layout>
-                                <v-toolbar-side-icon>
-                                <v-img class="mt-1" width=80px height=75px src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Heart-hand-shake.svg/256px-Heart-hand-shake.svg.png"></v-img>
-                                </v-toolbar-side-icon>
+                                <v-app-bar-nav-icon>
+                                <v-img class="mt-7" width=80px height=75px src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Heart-hand-shake.svg/256px-Heart-hand-shake.svg.png"></v-img>
+                                </v-app-bar-nav-icon>
                                 <div id="logo" class="pl-5 mt-5 headline font-weight-light white--text">einander-helfen.org</div>
                             </v-layout>
                         </v-col>


### PR DESCRIPTION
Change deprecated v-toolbar-side-icon to v-app-bar-nav-icon.

See [vuetify changelog](https://github.com/vuetifyjs/vuetify/releases/tag/v2.0.0-beta.0) and search for `v-toolbar-side-icon`

closes #309 