### PR TITLE
#287/display title correctly

### DIFF
--- a/app/src/components/posts/PostCard.vue
+++ b/app/src/components/posts/PostCard.vue
@@ -23,9 +23,7 @@
       </v-btn>
 
       <!--display title, subtitle and image on the right side-->
-      <div class="headline">
-        {{ post.title }}
-      </div>
+      <div class="headline" v-html="post.title"></div>
     </v-card-title>
     <v-card-text class="content">
       <v-simple-table dense>


### PR DESCRIPTION
fixe the details view title. E.g. search "Internationale Strolche" in "Köln"

![image](https://user-images.githubusercontent.com/25961416/119804999-273a8e00-bee1-11eb-8c9c-682b1019938b.png)

close 287