### PR TITLE
#236 fix scrolled down post detail view

### DIFF
--- a/app/src/components/posts/PostCard.vue
+++ b/app/src/components/posts/PostCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card v-show="show" class="post" tile v-if="post">
+  <v-card v-show="show" ref="card" class="post" tile v-if="post">
     <v-btn class="button-close" icon @click="closePost()">
       <v-icon>close</v-icon>
     </v-btn>
@@ -96,6 +96,14 @@ export default Vue.extend({
         { key: "source", label: "Quelle", link: "link" },
       ],
     };
+  },
+  watch: {
+    post() {
+      if (this.post && this.show) {
+        // scroll to top if post change
+        this.$el.scrollTop = 0;
+      }
+    },
   },
   methods: {
     openMap(): void {


### PR DESCRIPTION
When selecting a post, the detail view shows now the beginning of the offer.

close #236
