### PR TITLE
#271/use second index for elasticsearch upload

### DIFF
--- a/etl/scripts/run_etl.sh
+++ b/etl/scripts/run_etl.sh
@@ -5,9 +5,6 @@ cd /home/etl/einander-helfen/etl/scripts
 # Installing required python packages
 pip3 install -r ../requirements.txt
 
-# execute elastic upload
-python3 ../execute_elastic_upload.py
-
 # executing crawl and enhancement
 python3 ../main.py
 
@@ -16,3 +13,6 @@ tar cfvz enhanced_output.tar.gz ../data_enhancement/data ../data_enhancement/out
 
 # copy packaged data to make it available for nginx endpoint
 cp enhanced_output.tar.gz /var/www/html
+
+# execute elastic upload
+python3 ../execute_elastic_upload.py

--- a/etl/upload_to_elasticsearch/elastic.py
+++ b/etl/upload_to_elasticsearch/elastic.py
@@ -86,11 +86,13 @@ def _reindex_elastic():
             'index': index
         }
     }
+    try:
+        result = client.reindex(request_body, wait_for_completion=True, refresh=True, request_timeout=60)
 
-    result = client.reindex(request_body, wait_for_completion=True, refresh=True)
-
-    logger.info(f'Reindex info: {result["total"]} documents reindexed in {result["took"]} milliseconds')
-    logger.info(f'Failures: {result["failures"]}')
+        logger.info(f'Reindex info: {result["total"]} documents reindexed in {result["took"]} milliseconds')
+        logger.info(f'Failures: {result["failures"]}')
+    except Exception as err:
+        logger.exception(str(err))
 
     logger.info('Finished Reindexing!')
 

--- a/etl/upload_to_elasticsearch/elastic.py
+++ b/etl/upload_to_elasticsearch/elastic.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import time
 
 from elasticsearch import Elasticsearch
 
@@ -11,24 +12,35 @@ ROOT_DIR = os.environ['ROOT_DIR']
 client = Elasticsearch([{'host': '127.0.0.1', 'port': 9200}])
 logger = LoggerFactory.get_elastic_logger()
 
+index = 'posts'
+tmp_index = f'{index}_tmp'
+
+index_configuration = {
+    'mappings': {
+        'properties': {
+           'geo_location': {'type': 'geo_point'},
+        }}
+}
+
 
 def run_elastic_upload():
-    logger.debug("run_elastic_upload")
-    logger.info("Starting Index Process!")
+    logger.debug('run_elastic_upload()')
+    _create_temp_index()
+    _reset_old_index()
+    time.sleep(5)  # Timeout is necessary to prevent document loss during reindex
+    _reindex_elastic()
+    _delete_tmp_index()
 
-    index = 'posts'
-    if client.indices.exists(index=index):
-        client.indices.delete(index=index, ignore=[400, 404])
 
-    request_body = {
-        'mappings': {
-            'properties': {
-               'geo_location': {'type': 'geo_point'},
-            }}
-    }
+def _create_temp_index():
+    logger.debug('_create_temp_index()')
+    logger.info('Starting temporary Index Process!')
 
-    client.indices.create(index=index, body=request_body)
-    logger.info("Finished Indexing!")
+    if client.indices.exists(index=tmp_index):
+        client.indices.delete(index=tmp_index, ignore=[400, 404])
+
+    client.indices.create(index=tmp_index, body=index_configuration)
+    logger.info('Finished temporary Indexing!')
 
     for file in os.scandir(os.path.join(ROOT_DIR, 'data_management/upload')):
         logger.info(f'{file.name}: Starting data upload')
@@ -36,17 +48,56 @@ def run_elastic_upload():
         data = read_data_from_json(file.path)
 
         # Write enhanced data to Elastic Search
-        write_to_elastic(data, index)
+        _write_to_elastic(data)
         logger.info(f'{file.name}: Finished data upload')
 
 
-def write_to_elastic(posts, index):
-    logger.debug("write_to_elastic()")
+def _write_to_elastic(posts):
+    logger.debug('_write_to_elastic()')
 
     ids = []
     for post in posts:
         if post is not None:
             hashed_id = hashlib.md5(post['link'].encode()).hexdigest()
             if hashed_id not in ids:
-                client.create(id=hashed_id, index=index, doc_type='_doc', body=json.dumps(post))
+                client.create(id=hashed_id, index=tmp_index, doc_type='_doc', body=json.dumps(post))
                 ids.append(hashed_id)
+
+
+def _reset_old_index():
+    logger.debug('_reset_old_index()')
+    logger.info(f'Delete old {index} index')
+
+    if client.indices.exists(index=index):
+        client.indices.delete(index=index, ignore=[400, 404])
+
+    client.indices.create(index=index, body=index_configuration)
+
+
+def _reindex_elastic():
+    logger.debug('_reindex_elastic()')
+    logger.info('Starting Reindex Process!')
+
+    request_body = {
+        'source': {
+            'index': tmp_index
+        },
+        'dest': {
+            'index': index
+        }
+    }
+
+    result = client.reindex(request_body, wait_for_completion=True, refresh=True)
+
+    logger.info(f'Reindex info: {result["total"]} documents reindexed in {result["took"]} milliseconds')
+    logger.info(f'Failures: {result["failures"]}')
+
+    logger.info('Finished Reindexing!')
+
+
+def _delete_tmp_index():
+    logger.debug('_delete_tmp_index()')
+    logger.info(f'Delete {tmp_index} index')
+
+    if client.indices.exists(index=tmp_index):
+        client.indices.delete(index=tmp_index, ignore=[400, 404])


### PR DESCRIPTION
Refactored the elasticsearch upload:

1. Create temporary index (`posts_tmp`)
2. write new Data to the temporary index
3. Reinitialize main index (`posts`)
4. Reindex `posts_tmp` index with `posts` as destination
5. Delete `posts_tmp`