### PR TITLE
Use german osm data

### DIFF
--- a/app/src/components/posts/MapCard.vue
+++ b/app/src/components/posts/MapCard.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
   data: function () {
     return {
       map: {
-        url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        url: "https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png",
         attribution:
           '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
         center: [51.5, 10.5],


### PR DESCRIPTION
Use [german osm data](https://www.openstreetmap.de/germanstyle.html), so in nations that have no latin-letters, they will have an alternative name displayed.

![2021-06-17_14061623934695](https://user-images.githubusercontent.com/38251684/122401015-82a9ea00-cf7c-11eb-8e80-528d281a8787.png)


closes #325 