### PR TITLE
landing page image carousel fix

### DIFF
--- a/app/src/components/layout/Carousel.vue
+++ b/app/src/components/layout/Carousel.vue
@@ -41,6 +41,12 @@ img {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  cursor: pointer;
+  -webkit-user-drag: none;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
 .slick-arrow {
   display: none !important ;

--- a/app/src/components/layout/Carousel.vue
+++ b/app/src/components/layout/Carousel.vue
@@ -1,7 +1,8 @@
 <!-- The carousel contains images that are shown alternately every few seconds.-->
 
 <template>
-  <VueSlickCarousel class="carousel"
+  <VueSlickCarousel
+    class="carousel"
     :dots="true"
     :infinite="true"
     :autoplay="true"

--- a/app/src/components/layout/Carousel.vue
+++ b/app/src/components/layout/Carousel.vue
@@ -1,7 +1,7 @@
 <!-- The carousel contains images that are shown alternately every few seconds.-->
 
 <template>
-  <VueSlickCarousel
+  <VueSlickCarousel class="carousel"
     :dots="true"
     :infinite="true"
     :autoplay="true"
@@ -37,16 +37,14 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
+.carousel {
+  cursor: pointer;
+}
 img {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  cursor: pointer;
-  -webkit-user-drag: none;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
+  pointer-events: none;
 }
 .slick-arrow {
   display: none !important ;


### PR DESCRIPTION
The images inside the carousel component were still dragable, which lead to issues with the component. This has been removed.
Also the cursor was changed to pointer to suggest interaction by the user.