### PR TITLE
Add backend devcontainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__
 *.sln
 *.sw*
 etl/**/*.json
+!etl/.devcontainer/**/*.json
 etl/**/*.csv
 etl/**/*.log
 etl/logs

--- a/etl/.devcontainer/Dockerfile
+++ b/etl/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+ARG VARIANT="3.10-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && rm -rf /tmp/pip-tmp

--- a/etl/.devcontainer/devcontainer.json
+++ b/etl/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Python 3",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "VARIANT": "3.10-bullseye",
+      "NODE_VERSION": "none"
+    }
+  },
+  "settings": {
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+  },
+  "extensions": ["ms-python.python", "ms-python.vscode-pylance"],
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
This PR adds the files needed to run our backend app inside of a devcontainer. This one is much simpler than the FE one.

The container runs in Debian 11 using the current latest Python3 version (v3.10). Both are fixed.
For performance optimization, the pip dependencies are cached as a part of the base image. This might need to be changed if we expect them to change more often.

The container also includes the basic python extensions for VSCode.