### PR TITLE
#423 Avoidance of multiple parallel etl processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 etl/**/*.json
 etl/**/*.csv
 etl/**/*.log
+etl/**/*.tar.gz
 etl/logs
 etl/test/**/logs
 /etl/data_management/upload/

--- a/etl/scripts/run_etl.sh
+++ b/etl/scripts/run_etl.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
-#changing working dir
-cd /home/etl/einander-helfen/etl/scripts
+lockfile=/var/tmp/ETLlock
 
-# Installing required python packages
-pip3 install -r ../requirements.txt
+if ( set -o noclobber; echo "$$" > "$lockfile") 2> /dev/null; then
 
-# executing crawl and enhancement
-python3 ../main.py
+        trap 'rm -f "$lockfile"; exit $?' INT TERM EXIT
 
-# package enhanced data for prod
-tar cfvz enhanced_output.tar.gz ../data_enhancement/data ../data_enhancement/output
+        #changing working dir
+        cd /home/etl/einander-helfen/etl/scripts
 
-# copy packaged data to make it available for nginx endpoint
-cp enhanced_output.tar.gz /var/www/html
+        # Installing required python packages
+        pip3 install -r ../requirements.txt
 
-# execute elastic upload
-python3 ../execute_elastic_upload.py
+        # executing crawl and enhancement
+        python3 ../main.py
+
+        # package enhanced data for prod
+        tar cfvz enhanced_output.tar.gz ../data_enhancement/data ../data_enhancement/output
+
+        # copy packaged data to make it available for nginx endpoint
+        cp enhanced_output.tar.gz /var/www/html
+
+        # execute elastic upload
+        python3 ../execute_elastic_upload.py
+
+        # clean up after yourself, and release your trap
+        rm -f "$lockfile"
+        trap - INT TERM EXIT
+else
+        echo "Lock Exists: $lockfile owned by $(cat $lockfile)"
+fi

--- a/etl/scripts/run_etl.sh
+++ b/etl/scripts/run_etl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-lockfile=/var/tmp/ETLlock
+lockfile=./ETLlock
 
 if ( set -o noclobber; echo "$$" > "$lockfile") 2> /dev/null; then
 


### PR DESCRIPTION
Revised the `/etl/scripts/run_etel.sh` script to create a lockfile called `ETLlock` which prevents parallel execution of the script.

Closes #423 