### PR TITLE
#459 add meta fragment for better crawling 

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
-    <meta name="description" lang="de" content="Einander Helfen: ehrenamtliche Tätigkeit, fsj und föj sowie volunteering, betreuung und thw" />
+    <meta name="description" lang="de" content="Einander Helfen: ehrenamtliche Tätigkeit, fsj und föj, sowie volunteering, Betreuung und THW" />
     <link rel="icon" href="https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Heart-hand-shake.svg/256px-Heart-hand-shake.svg.png">
     <title>einander-helfen.org</title>
   </head>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="fragment" content="!">
     <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
+    <meta name="description" lang="de" content="Einander Helfen: ehrenamtliche Tätigkeit, fsj und föj sowie volunteering, betreuung und thw" />
     <link rel="icon" href="https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Heart-hand-shake.svg/256px-Heart-hand-shake.svg.png">
     <title>einander-helfen.org</title>
   </head>


### PR DESCRIPTION
Reason (Why?)
Crawler does not recognize links because of missing meta tags.

Solution (What?)
Add an meta description to each page to test the impact on SEO checkers.