### PR TITLE
Disable linting in be devcontainer settings

### DIFF
--- a/etl/.devcontainer/devcontainer.json
+++ b/etl/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   },
   "settings": {
     "python.defaultInterpreterPath": "/usr/local/bin/python",
-    "python.linting.enabled": true,
+    "python.linting.enabled": false,
     "python.linting.pylintEnabled": true,
     "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
     "python.formatting.blackPath": "/usr/local/py-utils/bin/black",


### PR DESCRIPTION
Disabled linting in devcontainer because it had too many issues and solving them would not be worth the time.