### PR TITLE
Pan map marker of current post

### DIFF
--- a/app/src/components/posts/MapCard.vue
+++ b/app/src/components/posts/MapCard.vue
@@ -22,7 +22,7 @@
         :options="{ gestureHandling: useGestureHandling }"
       >
         <LTileLayer :url="map.url" :attribution="map.attribution" />
-        <LMarckerCluster>
+        <LMarckerCluster :options="{ maxClusterRadius: 50 }">
           <Lmarker
             v-for="post in postWithGeoLocation"
             :key="post.id"
@@ -127,7 +127,15 @@ export default Vue.extend({
     },
   },
   mounted(): void {
-    this.rerenderMap();
+    if (this.show) {
+      this.$nextTick(() => {
+        (this.$refs.map as LMap).mapObject.invalidateSize();
+        this.$nextTick(() => {
+          this.setMapLocation();
+          this.fitMapBounds();
+        });
+      });
+    }
   },
   methods: {
     rerenderMap(): void {
@@ -135,7 +143,6 @@ export default Vue.extend({
         this.$nextTick(() => {
           (this.$refs.map as LMap).mapObject.invalidateSize();
           this.$nextTick(() => {
-            this.fitMapBounds();
             this.setMapLocation();
           });
         });
@@ -150,7 +157,9 @@ export default Vue.extend({
           this.selectedPost.geo_location.lat,
           this.selectedPost.geo_location.lon,
         ] as LatLngTuple;
-        (this.$refs.map as LMap).setCenter(location);
+        (this.$refs.map as LMap).mapObject.panTo(location);
+      } else {
+        this.fitMapBounds();
       }
     },
     /**

--- a/app/src/views/Posts.vue
+++ b/app/src/views/Posts.vue
@@ -10,7 +10,7 @@
       <v-flex class="map xs12 md6 order-md2">
         <!-- Map -->
         <MapCard
-          :show="!isSmartphone || showMap"
+          :show="showMap"
           :posts="posts"
           :selectedPost="selectedPost"
           @openPost="togglePostDetails"


### PR DESCRIPTION
Pan to the location of current active post.
Also fixed the problem that the map zoomed to the initial position after every reopening of the map instead of showing the current active post.
I set a lower than default maxClusterRadius (default is 80), because if two pins are close to each other, the cluster will be shown instead of the individual pin. There is now way to to this better, as the lib we are using does not offer support for zooming to an individual pin inside the cluster. 

closes #330