### PR TITLE
Open detailed post by clicking on a pin on mobile

### DIFF
--- a/app/src/components/layout/SearchHeader.vue
+++ b/app/src/components/layout/SearchHeader.vue
@@ -1,7 +1,11 @@
 <!-- This Header contains the logo, all components for searching and the burger menu. -->
 
 <template>
-  <header class="sticky_header" :class="{ expanded: expanded, fixed: fixed }">
+  <header
+    id="main_header"
+    class="sticky_header"
+    :class="{ expanded: expanded, fixed: fixed }"
+  >
     <div class="header_layout">
       <v-btn
         class="d-none d-sm-flex justify-center mr-4"

--- a/app/src/components/posts/MapCard.vue
+++ b/app/src/components/posts/MapCard.vue
@@ -25,13 +25,23 @@
         <LMarckerCluster>
           <Lmarker
             v-for="post in postWithGeoLocation"
+            ref="markerRef"
             :key="post.id"
             :icon="getMarker(post)"
             :lat-lng="[post.geo_location.lat, post.geo_location.lon]"
-            @click="openPost(post)"
+            @click="onMarkerClick(post)"
           >
-            <LTooltip>
-              <span :class="{ 'is-long': post.title.length >= 75 }">
+            <LTooltip
+              :options="{
+                interactive: true,
+                permanent: true,
+              }"
+              @click="onToolTipClick(post)"
+            >
+              <span
+                @click="onToolTipClick(post)"
+                :class="{ 'is-long': post.title.length >= 75 }"
+              >
                 {{ post.title }}
               </span>
             </LTooltip>
@@ -99,6 +109,8 @@ export default Vue.extend({
           iconSize: [25, 41],
         }),
       },
+      selectedMarkerMobile: undefined as Post | undefined,
+      isSmartphone: false,
     };
   },
   computed: {
@@ -128,6 +140,9 @@ export default Vue.extend({
   },
   mounted(): void {
     this.rerenderMap();
+    if (window.matchMedia("(max-width: 959px)").matches) {
+      this.isSmartphone = true;
+    }
   },
   methods: {
     rerenderMap(): void {
@@ -182,6 +197,17 @@ export default Vue.extend({
     },
     openPost(post: Post): void {
       this.$emit("openPost", post);
+    },
+    onMarkerClick(post: Post): void {
+      if (this.isSmartphone) {
+        this.selectedMarkerMobile = post;
+        return;
+      }
+      this.openPost(post);
+    },
+    onToolTipClick(post: Post): void {
+      this.selectedMarkerMobile = undefined;
+      this.openPost(post);
     },
     isMobile(): boolean {
       if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {

--- a/app/src/views/Posts.vue
+++ b/app/src/views/Posts.vue
@@ -237,9 +237,20 @@ export default Vue.extend({
         // update uri
         this.updateURIFromState();
         const item = document.getElementById(id ? id : "");
+        const header = document.getElementById("main_header");
 
-        if (item) {
-          item.scrollIntoView(true);
+        // scroll to the postItem, so the item is below our header
+        if (this.isSmartphone && item && header) {
+          const offset = header.scrollHeight;
+          const bodyRect = document.body.getBoundingClientRect().top;
+          const elementRect = item.getBoundingClientRect().top;
+          const elementPosition = elementRect - bodyRect;
+          const offsetPosition = elementPosition - offset;
+
+          window.scrollTo({
+            top: offsetPosition,
+            behavior: "smooth",
+          });
         }
       });
     },

--- a/app/src/views/Posts.vue
+++ b/app/src/views/Posts.vue
@@ -61,6 +61,7 @@
           <PostListItem
             v-for="post in postsOnCurrentPage"
             :key="post.id"
+            :id="post.id"
             :post="post"
             :active="post.id == selectedPostId"
             :showDetail="isSmartphone"
@@ -232,10 +233,15 @@ export default Vue.extend({
       if (!post && !this.isSmartphone) this.showMap = true;
       // set selected post id or set undefined in store
       const id = post ? post.id : undefined;
-      this.setSelectedPostId(id).then(() =>
+      this.setSelectedPostId(id).then(() => {
         // update uri
-        this.updateURIFromState()
-      );
+        this.updateURIFromState();
+        const item = document.getElementById(id ? id : "");
+
+        if (item) {
+          item.scrollIntoView(true);
+        }
+      });
     },
     /** Show the map  */
     openMap(): void {


### PR DESCRIPTION
When clicking on the text of a pin, scroll to the detail description of the post.

There is 1 Issue that needs to be discussed:
The issue stated, that the post should only be opened by clicking  a second time on the pin (or more specific clicking on the text of the pin). The click event will be captured by the map itself rather that the pin text which results in closing the pin text before the click-handler of the pin text can fire. So the feature does only work if we always show the pin text rather than only showing it after tapping the pin.
As far as i found out it is not possible to dynamically toggle the text to keep open for the current selected post.

So we have 3 options:
1.  Close this issue as not possible
2. always keep the pin text open on mobile
3. scroll to the post description when clicking on the pin instead of showing the text on the map.

I'm open to other ideas as well.

I have to say that while working on this i think we should discuss whether we want to have the pin text always visible as its makes it easier for the user to see what the job is without the need to press on the pin first.

closes #328 