### PR TITLE
Add robots.txt blocking /posts urls

### DIFF
--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,2 @@
+User-Agent: *
+Disallow: /posts 


### PR DESCRIPTION
This PR simply adds a robots.txt which allows all crawlers, but blocks them from indexing /posts