### PR TITLE
Add canoncial tags with help from vue-meta

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "material-design-icons-iconfont": "~6.1.0",
     "vue": "^2.6.13",
     "vue-matomo": "^4.1.0",
+    "vue-meta": "^2.4.0",
     "vue-router": "~3.4.9",
     "vue-slick-carousel": "~1.0.6",
     "vue2-leaflet": "~2.6.0",

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -5,6 +5,7 @@ import store from "@/store/store";
 
 import Vuetify from "vuetify";
 import VueMatomo from "vue-matomo";
+import VueMeta from "vue-meta";
 
 // import vuetify css
 import "vuetify/dist/vuetify.min.css";
@@ -21,6 +22,7 @@ import de from "vuetify/es5/locale/de.js";
 Vue.config.productionTip = false;
 
 Vue.use(Vuetify);
+Vue.use(VueMeta);
 
 const vuetify = new Vuetify({
   lang: {

--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -154,13 +154,9 @@ export default Vue.extend({
   components: {
     Header,
   },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Über uns - Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Über uns - Einander Helfen",
+    link: [{ rel: "canonical", href: "https://einander-helfen.org/about" }],
   },
 });
 </script>

--- a/app/src/views/Home.vue
+++ b/app/src/views/Home.vue
@@ -32,13 +32,9 @@ export default Vue.extend({
     SearchComponent,
     ImageCards,
   },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Einander Helfen",
+    link: [{ rel: "canonical", href: "https://einander-helfen.org" }],
   },
   data: function () {
     return {

--- a/app/src/views/Imprint.vue
+++ b/app/src/views/Imprint.vue
@@ -97,13 +97,9 @@ import Header from "@/components/layout/SearchHeader.vue";
 
 export default Vue.extend({
   components: { Header },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Impressum - Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Impressum - Einander Helfen",
+    link: [{ rel: "canonical", href: "https://einander-helfen.org/imprint" }],
   },
   data(): {
     items: any;

--- a/app/src/views/Organizations.vue
+++ b/app/src/views/Organizations.vue
@@ -43,13 +43,11 @@ export default Vue.extend({
   components: {
     Header,
   },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Anbieter - Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Anbieter - Einander Helfen",
+    link: [
+      { rel: "canonical", href: "https://einander-helfen.org/organizations" },
+    ],
   },
   data() {
     return {

--- a/app/src/views/PageNotFound.vue
+++ b/app/src/views/PageNotFound.vue
@@ -28,13 +28,8 @@ export default Vue.extend({
   components: {
     Header,
   },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Seite nicht gefunden - Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Seite nicht gefunden - Einander Helfen",
   },
   computed: {
     width() {

--- a/app/src/views/Posts.vue
+++ b/app/src/views/Posts.vue
@@ -107,6 +107,9 @@ export default Vue.extend({
     PostListItem,
     PostListItemSkeleton,
   },
+  metaInfo: {
+    title: "Ergebnisse - Einander Helfen",
+  },
   data: function () {
     return {
       showMap: true,
@@ -137,12 +140,6 @@ export default Vue.extend({
     searchValues() {
       // recalc header space after search tags change
       this.$nextTick(() => this.calcHeaderSpace());
-    },
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Ergebnisse - Einander Helfen";
-      },
     },
   },
   async mounted(): Promise<void> {

--- a/app/src/views/Privacy.vue
+++ b/app/src/views/Privacy.vue
@@ -323,13 +323,9 @@ export default Vue.extend({
   components: {
     Header,
   },
-  watch: {
-    title: {
-      immediate: true,
-      handler() {
-        document.title = "Datenschutz - Einander Helfen";
-      },
-    },
+  metaInfo: {
+    title: "Datenschutz - Einander Helfen",
+    link: [{ rel: "canonical", href: "https://einander-helfen.org/privacy" }],
   },
 });
 </script>

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -11092,6 +11092,13 @@ vue-matomo@^4.1.0:
   resolved "https://registry.yarnpkg.com/vue-matomo/-/vue-matomo-4.1.0.tgz#17b513bc8ac60e168bfa8190ad05b3257a3c441e"
   integrity sha512-y+tdmhY835Ip3EAGfIAgA33+aBYrvRT7fNnBnA7bSM459XpoWXgqJKdbopVpEUrxCPIq8IkuF7g4KqSLc0Fa3w==
 
+vue-meta@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"
+  integrity sha512-XEeZUmlVeODclAjCNpWDnjgw+t3WA6gdzs6ENoIAgwO1J1d5p1tezDhtteLUFwcaQaTtayRrsx7GL6oXp/m2Jw==
+  dependencies:
+    deepmerge "^4.2.2"
+
 vue-router@~3.4.9:
   version "3.4.9"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.9.tgz#c016f42030ae2932f14e4748b39a1d9a0e250e66"


### PR DESCRIPTION
Adds canonical tags to all views (without our non-indexed posts).
This is achieved using [vue-meta](https://vue-meta.nuxtjs.org/) which seems to be the standard for managing meta tags for seo.
As vue-meta  also manage the document titles, I refactored our code so we use vue-meta for this also.

closes #511
and duplicate issue:
closes #456 